### PR TITLE
feat(frontend): Playwright smoke tests (shell, connect, dashboard guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,25 @@ npm run dev:backend    # Express on port 3001
 - Backend API: http://localhost:3001
 - Backend Health: http://localhost:3001/health
 
+### Playwright smoke tests (E2E)
+
+Configuration and tests live under **`frontend/`** (separate from Vitest unit tests).
+
+```bash
+cd frontend
+npm install
+npx playwright install chromium
+```
+
+Run (starts or reuses the Next dev server on port 3000):
+
+```bash
+cd frontend
+npx playwright test
+```
+
+Smoke coverage: `/menu` shell, `/connect` entry, `/dashboard` guard (unauthenticated users end on `/menu`), and `/dashboard` with a documented **`localStorage` wallet stub** (see `frontend/e2e/smoke.spec.ts`) so Freighter is not required headless.
+
 ---
 
 ## Usage Guide
@@ -410,6 +429,7 @@ struct DriverConfig {
 - [x] Escrow services (Trustless Work)
 - [x] Soroban contract skeleton
 - [x] Database schema
+- [x] Playwright smoke E2E (`frontend/`, `npx playwright test`)
 
 ### ⚠️ In Progress
 
@@ -421,7 +441,7 @@ struct DriverConfig {
 ### ❌ Pending
 
 - [ ] Production environment variables
-- [ ] E2E testing
+- [ ] Full E2E coverage beyond Playwright smoke (Freighter-heavy flows, CI wiring)
 - [ ] Deployment configuration
 
 ---

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('smoke', () => {
+  test('marketing shell loads without server error', async ({ page }) => {
+    const res = await page.goto('/menu');
+    expect(res?.ok()).toBeTruthy();
+    await expect(page.getByRole('heading', { name: 'TANKO' }).first()).toBeVisible();
+  });
+
+  test('connect entry page renders', async ({ page }) => {
+    const res = await page.goto('/connect');
+    expect(res?.ok()).toBeTruthy();
+    await expect(page.getByRole('heading', { name: 'TANKO' })).toBeVisible();
+  });
+
+  test('dashboard guard: unauthenticated user is sent away from /dashboard', async ({
+    page,
+  }) => {
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/menu$/, { timeout: 30_000 });
+    expect(page.url()).toMatch(/\/menu$/);
+  });
+
+  test('dashboard with localStorage wallet stub shows fleet shell', async ({ page }) => {
+    const stellar =
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    await page.addInitScript(
+      ({ addr, role }: { addr: string; role: string }) => {
+        window.localStorage.setItem('tanko_stellar_address', addr);
+        window.localStorage.setItem('tanko_user_role', role);
+      },
+      { addr: stellar, role: 'JEFE' },
+    );
+
+    await page.goto('/dashboard');
+    await expect(page.getByRole('link', { name: 'Overview' })).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.0.1",
@@ -68,6 +69,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@tailwindcss/postcss": "^4.2.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    cwd: __dirname,
+  },
+});


### PR DESCRIPTION
## Summary
- Playwright configured under `frontend/` (`playwright.config.ts`, `e2e/smoke.spec.ts`).
- Smoke tests: `/menu` shell, `/connect` entry, `/dashboard` unauthenticated redirect to `/menu`, and `/dashboard` with documented `localStorage` wallet stub (no Freighter in CI).
- Root README: how to run `npx playwright test` from `frontend/`.

## Test plan
- [x] `cd frontend && npm install && npx playwright install chromium && npx playwright test` (run locally in agent environment when deps available)
- [ ] Maintainer: confirm CI / local lint as needed

Fixes #11

Made with [Cursor](https://cursor.com)