### PR TITLE
feat: add GasStation model, CRUD API, and update ubicaciones page

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -89,6 +89,23 @@ model FundRequest {
   @@index([status])
 }
 
+model GasStation {
+  id        String   @id @default(uuid())
+  name      String
+  address   String
+  city      String?
+  state     String?
+  lat       Float?
+  lng       Float?
+  hours     String?
+  services  String[] @default([])
+  status    String   @default("ACTIVE")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status])
+}
+
 model EscrowConfig {
   id          String   @id @default(uuid())
   name        String   @default("default")

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -17,6 +17,7 @@ async function main() {
   await prisma.unit.deleteMany();
   await prisma.user.deleteMany();
   await prisma.escrowConfig.deleteMany();
+  await prisma.gasStation.deleteMany();
 
   console.log('Cleared existing data');
 
@@ -301,6 +302,88 @@ async function main() {
     }),
   ]);
   console.log('Created', fundRequests.length, 'fund requests');
+
+  const stations = await Promise.all([
+    prisma.gasStation.create({
+      data: {
+        name: 'Central CDMX Station',
+        address: 'Av. Insurgentes Sur 1234, Del Valle',
+        city: 'Ciudad de México',
+        state: 'CDMX',
+        lat: 19.3910,
+        lng: -99.1787,
+        hours: '24 horas',
+        services: ['Diesel', 'Magna', 'Premium', 'Aire'],
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.gasStation.create({
+      data: {
+        name: 'Reforma Station',
+        address: 'Paseo de la Reforma 567, Juárez',
+        city: 'Ciudad de México',
+        state: 'CDMX',
+        lat: 19.4284,
+        lng: -99.1558,
+        hours: '06:00 - 22:00',
+        services: ['Diesel', 'Magna', 'Premium'],
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.gasStation.create({
+      data: {
+        name: 'North Station',
+        address: 'Blvd. Manuel Ávila Camacho 890',
+        city: 'Ciudad de México',
+        state: 'CDMX',
+        lat: 19.4876,
+        lng: -99.2234,
+        hours: '24 horas',
+        services: ['Diesel', 'Magna', 'Lavado'],
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.gasStation.create({
+      data: {
+        name: 'South Express Station',
+        address: 'Calzada de Tlalpan 2345',
+        city: 'Ciudad de México',
+        state: 'CDMX',
+        lat: 19.3012,
+        lng: -99.1456,
+        hours: '05:00 - 23:00',
+        services: ['Diesel', 'Magna'],
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.gasStation.create({
+      data: {
+        name: 'East Station',
+        address: 'Av. Zaragoza 678, Balbuena',
+        city: 'Ciudad de México',
+        state: 'CDMX',
+        lat: 19.4123,
+        lng: -99.0987,
+        hours: '24 horas',
+        services: ['Diesel', 'Magna', 'Premium', 'Aire', 'Agua'],
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.gasStation.create({
+      data: {
+        name: 'Querétaro Central',
+        address: 'Av. Constituyentes 456, Centro',
+        city: 'Querétaro',
+        state: 'Querétaro',
+        lat: 20.5881,
+        lng: -100.3899,
+        hours: '24 horas',
+        services: ['Diesel', 'Magna', 'Premium'],
+        status: 'ACTIVE',
+      },
+    }),
+  ]);
+  console.log('Created', stations.length, 'gas stations');
 
   console.log('Seed completed successfully!');
 }

--- a/backend/src/controllers/station.controller.ts
+++ b/backend/src/controllers/station.controller.ts
@@ -1,0 +1,57 @@
+import { Request, Response } from 'express';
+import { stationRepository, CreateStationDTO, UpdateStationDTO } from '../repositories/station.repository.js';
+
+export class StationController {
+  async getAll(req: Request, res: Response): Promise<void> {
+    try {
+      const activeOnly = req.query.active === 'true';
+      const stations = activeOnly
+        ? await stationRepository.findActive()
+        : await stationRepository.findAll();
+      res.json({ success: true, data: stations });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to fetch stations' });
+    }
+  }
+
+  async getById(req: Request, res: Response): Promise<void> {
+    try {
+      const station = await stationRepository.findById(req.params.id);
+      if (!station) { res.status(404).json({ success: false, error: 'Station not found' }); return; }
+      res.json({ success: true, data: station });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to fetch station' });
+    }
+  }
+
+  async create(req: Request, res: Response): Promise<void> {
+    try {
+      const station = await stationRepository.create(req.body as CreateStationDTO);
+      res.status(201).json({ success: true, data: station });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to create station' });
+    }
+  }
+
+  async update(req: Request, res: Response): Promise<void> {
+    try {
+      const station = await stationRepository.update(req.params.id, req.body as UpdateStationDTO);
+      res.json({ success: true, data: station });
+    } catch (error: any) {
+      if (error.code === 'P2025') { res.status(404).json({ success: false, error: 'Station not found' }); return; }
+      res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to update station' });
+    }
+  }
+
+  async delete(req: Request, res: Response): Promise<void> {
+    try {
+      await stationRepository.delete(req.params.id);
+      res.json({ success: true, message: 'Station deleted' });
+    } catch (error: any) {
+      if (error.code === 'P2025') { res.status(404).json({ success: false, error: 'Station not found' }); return; }
+      res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to delete station' });
+    }
+  }
+}
+
+export const stationController = new StationController();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import userRoutes from './routes/user.routes.js';
 import unitRoutes from './routes/unit.routes.js';
 import fuelLogRoutes from './routes/fuelLog.routes.js';
 import configRoutes from './routes/config.routes.js';
+import stationRoutes from './routes/station.routes.js';
 
 const app = express();
 
@@ -44,6 +45,7 @@ app.use('/api/v1', userRoutes);
 app.use('/api/v1', unitRoutes);
 app.use('/api/v1', fuelLogRoutes);
 app.use('/api/v1', configRoutes);
+app.use('/api/v1', stationRoutes);
 app.use('/api/v1/helper', helperRoutes);
 
 app.use((req: Request, res: Response) => {

--- a/backend/src/repositories/station.repository.ts
+++ b/backend/src/repositories/station.repository.ts
@@ -1,0 +1,43 @@
+import prisma from '../db/prisma.js';
+
+export interface CreateStationDTO {
+  name: string;
+  address: string;
+  city?: string;
+  state?: string;
+  lat?: number;
+  lng?: number;
+  hours?: string;
+  services?: string[];
+  status?: string;
+}
+
+export interface UpdateStationDTO extends Partial<CreateStationDTO> {}
+
+export class StationRepository {
+  findAll() {
+    return prisma.gasStation.findMany({ orderBy: { name: 'asc' } });
+  }
+
+  findById(id: string) {
+    return prisma.gasStation.findUnique({ where: { id } });
+  }
+
+  findActive() {
+    return prisma.gasStation.findMany({ where: { status: 'ACTIVE' }, orderBy: { name: 'asc' } });
+  }
+
+  create(data: CreateStationDTO) {
+    return prisma.gasStation.create({ data });
+  }
+
+  update(id: string, data: UpdateStationDTO) {
+    return prisma.gasStation.update({ where: { id }, data });
+  }
+
+  delete(id: string) {
+    return prisma.gasStation.delete({ where: { id } });
+  }
+}
+
+export const stationRepository = new StationRepository();

--- a/backend/src/routes/station.routes.ts
+++ b/backend/src/routes/station.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { stationController } from '../controllers/station.controller.js';
+
+const router = Router();
+
+router.get('/stations', (req, res) => stationController.getAll(req, res));
+router.get('/stations/:id', (req, res) => stationController.getById(req, res));
+router.post('/stations', (req, res) => stationController.create(req, res));
+router.put('/stations/:id', (req, res) => stationController.update(req, res));
+router.delete('/stations/:id', (req, res) => stationController.delete(req, res));
+
+export default router;

--- a/frontend/app/dashboard/ubicaciones/page.tsx
+++ b/frontend/app/dashboard/ubicaciones/page.tsx
@@ -1,85 +1,55 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { 
-  MapPin, 
-  Search,
-  Fuel,
-  Loader2,
-  AlertCircle,
-  Star,
-  Clock,
-} from "lucide-react"
+import { MapPin, Search, Fuel, Loader2, AlertCircle, Clock } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://127.0.0.1:3001"
 
-interface Location {
+interface GasStation {
   id: string
   name: string
   address: string
   city?: string
-  coordinates?: string
+  state?: string
+  lat?: number
+  lng?: number
   hours?: string
-  services?: string[]
+  services: string[]
+  status: string
 }
 
 export default function LocationsPage() {
-  const [locations, setLocations] = useState<Location[]>([])
+  const [stations, setStations] = useState<GasStation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
 
   useEffect(() => {
-    async function fetchLocations() {
-      console.log(`[Locations] Fetching from ${BACKEND}/api/v1/stats/recent-transactions`)
+    async function fetchStations() {
       setLoading(true)
       setError(null)
-
       try {
-        const res = await fetch(`${BACKEND}/api/v1/stats/recent-transactions?limit=100`)
-        console.log(`[Locations] Response status: ${res.status}`)
-
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`)
-        }
-
+        const res = await fetch(`${BACKEND}/api/v1/stations`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const data = await res.json()
-        console.log(`[Locations] Response:`, data)
-
-        if (data.success && data.data) {
-          const uniqueStations = new Map<string, Location>()
-          data.data.forEach((tx: any) => {
-            if (tx.station && !uniqueStations.has(tx.station)) {
-              uniqueStations.set(tx.station, {
-                id: tx.id,
-                name: tx.station,
-                address: tx.station,
-                city: "México",
-              })
-            }
-          })
-          setLocations(Array.from(uniqueStations.values()))
-        } else {
-          setLocations([])
-        }
+        setStations(data.success ? data.data : [])
       } catch (err) {
-        console.error("[Locations] Error fetching data:", err)
         setError(err instanceof Error ? err.message : "Error de conexión")
-        setLocations([])
+        setStations([])
       } finally {
         setLoading(false)
       }
     }
-
-    fetchLocations()
+    fetchStations()
   }, [])
 
-  const filteredLocations = locations.filter(loc =>
-    loc.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    loc.address?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    loc.city?.toLowerCase().includes(searchQuery.toLowerCase())
+  const filtered = stations.filter(s =>
+    s.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    s.address.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    s.city?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    s.state?.toLowerCase().includes(searchQuery.toLowerCase())
   )
 
   if (loading) {
@@ -109,17 +79,17 @@ export default function LocationsPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-foreground">Ubicaciones</h1>
-        <p className="text-muted-foreground">Gasolineras donde la flota ha cargado combustible</p>
+        <p className="text-muted-foreground">Gasolineras registradas para la flota</p>
       </div>
 
       <Card>
         <CardHeader>
           <CardTitle>Gasolineras</CardTitle>
-          <CardDescription>Estaciones donde se han registrado cargas de combustible</CardDescription>
+          <CardDescription>{stations.length} estación{stations.length !== 1 ? "es" : ""} registrada{stations.length !== 1 ? "s" : ""}</CardDescription>
           <div className="relative mt-3">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
-              placeholder="Buscar estación..."
+              placeholder="Buscar por nombre, dirección o ciudad..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-10"
@@ -127,43 +97,49 @@ export default function LocationsPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {filteredLocations.length > 0 ? (
+          {filtered.length === 0 ? (
+            <p className="py-8 text-center text-muted-foreground">
+              {searchQuery ? "Sin resultados para tu búsqueda" : "No hay gasolineras registradas"}
+            </p>
+          ) : (
             <div className="space-y-4">
-              {filteredLocations.map((location) => (
+              {filtered.map((station) => (
                 <div
-                  key={location.id}
+                  key={station.id}
                   className="flex items-start gap-4 rounded-xl border border-border p-4 transition-all hover:border-primary/30"
                 >
                   <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
                     <Fuel className="h-6 w-6 text-primary" />
                   </div>
-                  <div className="flex-1">
-                    <h4 className="font-semibold text-foreground">{location.name}</h4>
-                    <p className="text-sm text-muted-foreground">{location.address}</p>
-                    {location.city && (
-                      <p className="text-xs text-muted-foreground">{location.city}</p>
+                  <div className="flex-1 min-w-0">
+                    <h4 className="font-semibold text-foreground">{station.name}</h4>
+                    <p className="text-sm text-muted-foreground">{station.address}</p>
+                    {(station.city || station.state) && (
+                      <p className="text-xs text-muted-foreground">
+                        {[station.city, station.state].filter(Boolean).join(", ")}
+                      </p>
                     )}
-                    {location.coordinates && (
-                      <p className="text-xs text-muted-foreground font-mono mt-1">
-                        {location.coordinates}
+                    {station.lat != null && station.lng != null && (
+                      <p className="mt-1 font-mono text-xs text-muted-foreground">
+                        {station.lat.toFixed(4)}, {station.lng.toFixed(4)}
                       </p>
                     )}
                   </div>
-                  <div className="flex flex-col items-end gap-2">
-                    {location.hours && (
+                  <div className="flex flex-col items-end gap-2 shrink-0">
+                    {station.hours && (
                       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                         <Clock className="h-3 w-3" />
-                        {location.hours}
+                        {station.hours}
                       </div>
                     )}
-                    {location.services && location.services.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {location.services.map((service, idx) => (
+                    {station.services.length > 0 && (
+                      <div className="flex flex-wrap justify-end gap-1">
+                        {station.services.map((svc) => (
                           <span
-                            key={idx}
+                            key={svc}
                             className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
                           >
-                            {service}
+                            {svc}
                           </span>
                         ))}
                       </div>
@@ -172,8 +148,6 @@ export default function LocationsPage() {
                 </div>
               ))}
             </div>
-          ) : (
-            <p className="text-center py-8 text-muted-foreground">No hay ubicaciones registradas</p>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
  Replaces the placeholder data source on /dashboard/ubicaciones (previously derived from stats/recent-transactions)  
  with a first-class GasStation model.                                                                                
                                                                                                                      
  Changes                                                                                                             
                                                                                                                      
  - Schema: Added GasStation Prisma model with name, address, city, state, lat/lng (nullable), hours, services[], and 
  status                                                                                                              
  - API: GET /api/v1/stations returns all stations; full CRUD available (POST, PUT, DELETE) — write restriction to    
  JEFE role deferred until global auth middleware is in place                                                         
  - Seed: 6 gas stations seeded, matching stations already referenced in FuelLog records                              
  - Frontend: /dashboard/ubicaciones now fetches from /api/v1/stations with proper loading, empty, and error states   
                                                                                                                      
  Validation                                                                                                          
                                                                                                                      
  cd backend                                                                                                          
  npx prisma db push                                                                                                  
  npx prisma db seed                                                                                                  
  # GET http://localhost:3001/api/v1/stations → { success: true, data: [...] } 

Closes #14 