### PR TITLE
feat: implement driver registration flow with manager-driver hierarch…

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,13 +14,18 @@ model User {
   stellarPubKey String? @unique
   role          String    @default("CONDUCTOR")
   status        String    @default("ACTIVE")
+  managerId     String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
+  manager          User?         @relation("ManagerDrivers", fields: [managerId], references: [id])
+  drivers          User[]        @relation("ManagerDrivers")
   units            Unit[]
   driverRequests   FundRequest[] @relation("driver")
-  managerRequests FundRequest[] @relation("manager")
-  fuelLogs        FuelLog[]
+  managerRequests  FundRequest[] @relation("manager")
+  fuelLogs         FuelLog[]
+
+  @@index([managerId])
 }
 
 model Unit {

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { userRepository, CreateUserDTO, UpdateUserDTO, UserRole } from '../repositories/user.repository.js';
+import { userService } from '../services/user.service.js';
 
 export class UserController {
   async getAll(req: Request, res: Response): Promise<void> {
@@ -119,6 +120,35 @@ export class UserController {
       });
     }
   }
+
+  /**
+   * POST /api/v1/users/register-driver
+   * Registers a new CONDUCTOR under the requesting JEFE manager.
+   * Expects header: x-stellar-pubkey (manager's public key)
+   * Body: { name: string, stellarPubKey: string }
+   */
+  async registerDriver(req: Request, res: Response): Promise<void> {
+    try {
+      const managerPubKey = req.headers['x-stellar-pubkey'] as string;
+      if (!managerPubKey) {
+        res.status(400).json({
+          success: false,
+          error: 'x-stellar-pubkey header is required',
+        });
+        return;
+      }
+
+      const driver = await userService.registerDriver(managerPubKey, req.body);
+      res.status(201).json({ success: true, data: driver });
+    } catch (error: any) {
+      const status = error.status || 500;
+      res.status(status).json({
+        success: false,
+        error: error.message || 'Failed to register driver',
+      });
+    }
+  }
 }
 
 export const userController = new UserController();
+

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -10,6 +10,7 @@ export interface CreateUserDTO {
   stellarPubKey?: string;
   role?: UserRole;
   status?: Status;
+  managerId?: string;
 }
 
 export interface UpdateUserDTO {
@@ -19,6 +20,7 @@ export interface UpdateUserDTO {
   stellarPubKey?: string;
   role?: UserRole;
   status?: Status;
+  managerId?: string;
 }
 
 export class UserRepository {
@@ -67,6 +69,14 @@ export class UserRepository {
     return prisma.user.count({ where: { role } });
   }
 
+  async findDriversByManagerId(managerId: string) {
+    return prisma.user.findMany({
+      where: { managerId, role: 'CONDUCTOR' },
+      include: { units: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
   async getDriversWithStats(managerPubKey: string) {
     return prisma.user.findMany({
       where: { role: 'CONDUCTOR' },
@@ -82,3 +92,4 @@ export class UserRepository {
 }
 
 export const userRepository = new UserRepository();
+

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -7,6 +7,8 @@ router.get('/users', (req, res) => userController.getAll(req, res));
 
 router.get('/users/drivers', (req, res) => userController.getDriversWithStats(req, res));
 
+router.post('/users/register-driver', (req, res) => userController.registerDriver(req, res));
+
 router.get('/users/:id', (req, res) => userController.getById(req, res));
 
 router.get('/users/stellar/:publicKey', (req, res) => userController.getByStellarPubKey(req, res));
@@ -18,3 +20,4 @@ router.put('/users/:id', (req, res) => userController.update(req, res));
 router.delete('/users/:id', (req, res) => userController.delete(req, res));
 
 export default router;
+

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,0 +1,72 @@
+import { userRepository } from '../repositories/user.repository.js';
+import { registerDriverSchema } from '../utils/validators.js';
+
+export class UserService {
+  /**
+   * Registers a new CONDUCTOR driver under a JEFE manager.
+   *
+   * @param managerPubKey – The Stellar public key of the requesting manager.
+   * @param data          – { name, stellarPubKey } for the new driver.
+   * @returns The created driver record.
+   */
+  async registerDriver(
+    managerPubKey: string,
+    data: { name: string; stellarPubKey: string },
+  ) {
+    // 1. Validate request body
+    const parsed = registerDriverSchema.safeParse(data);
+    if (!parsed.success) {
+      const messages = parsed.error.errors.map((e) => e.message).join('; ');
+      const err = new Error(messages) as Error & { status: number };
+      err.status = 400;
+      throw err;
+    }
+
+    // 2. Look up the requesting user and verify JEFE role
+    const manager = await userRepository.findByStellarPubKey(managerPubKey);
+    if (!manager) {
+      const err = new Error('Manager not found') as Error & { status: number };
+      err.status = 404;
+      throw err;
+    }
+    if (manager.role !== 'JEFE') {
+      const err = new Error(
+        'Only users with the JEFE role can register drivers',
+      ) as Error & { status: number };
+      err.status = 403;
+      throw err;
+    }
+
+    // 3. Check for duplicate Stellar Public Key
+    const existing = await userRepository.findByStellarPubKey(
+      parsed.data.stellarPubKey,
+    );
+    if (existing) {
+      const err = new Error(
+        'A user with this Stellar Public Key already exists',
+      ) as Error & { status: number };
+      err.status = 409;
+      throw err;
+    }
+
+    // 4. Create the driver linked to this manager
+    const driver = await userRepository.create({
+      name: parsed.data.name,
+      stellarPubKey: parsed.data.stellarPubKey,
+      email: `${parsed.data.stellarPubKey.slice(0, 8).toLowerCase()}@tanko.driver`,
+      role: 'CONDUCTOR',
+      managerId: manager.id,
+    });
+
+    return driver;
+  }
+
+  /**
+   * Returns all drivers managed by the given manager id.
+   */
+  async getDriversByManagerId(managerId: string) {
+    return userRepository.findDriversByManagerId(managerId);
+  }
+}
+
+export const userService = new UserService();

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -106,3 +106,21 @@ export type GetEscrowsByRoleInput = z.infer<typeof getEscrowsByRoleSchema>;
 export type GetMultipleBalancesInput = z.infer<typeof getMultipleBalancesSchema>;
 export type DisputeEscrowInput = z.infer<typeof disputeEscrowSchema>;
 export type ResolveDisputeInput = z.infer<typeof resolveDisputeSchema>;
+
+// ── Driver Registration ──────────────────────────────────────────────
+
+/** Stellar Public Key: base32, 56 characters, starts with 'G'. */
+export const stellarPubKeySchema = z
+  .string()
+  .length(56, 'Stellar Public Key must be exactly 56 characters')
+  .regex(
+    /^G[A-Z2-7]{55}$/,
+    'Invalid Stellar Public Key format (must start with G, uppercase letters A-Z and digits 2-7)',
+  );
+
+export const registerDriverSchema = z.object({
+  name: z.string().min(1, 'Driver name is required').max(100, 'Name must be 100 characters or less'),
+  stellarPubKey: stellarPubKeySchema,
+});
+
+export type RegisterDriverInput = z.infer<typeof registerDriverSchema>;

--- a/frontend/app/dashboard/usuarios/page.tsx
+++ b/frontend/app/dashboard/usuarios/page.tsx
@@ -1,27 +1,28 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { 
   Search, 
-  Plus, 
-  MoreHorizontal, 
   Mail, 
   Phone,
   Car,
-  Eye,
   Loader2,
   AlertCircle,
+  UserPlus,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 import { useAuth } from "@/providers/auth-provider"
+import RegisterDriverForm from "@/components/forms/RegisterDriverForm"
 
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://127.0.0.1:3001"
 
@@ -32,6 +33,7 @@ interface User {
   phone?: string
   stellarPubKey: string
   role: string
+  managerId?: string | null
   units?: Array<{
     id: string
     plates: string
@@ -42,45 +44,51 @@ interface User {
 }
 
 export default function UsersPage() {
-  const { address: walletAddress } = useAuth()
+  const { address: walletAddress, role: userRole } = useAuth()
   const [users, setUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const fetchUsers = useCallback(async () => {
+    console.log(`[Users] Fetching from ${BACKEND}/api/v1/users`)
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`${BACKEND}/api/v1/users`)
+      console.log(`[Users] Response status: ${res.status}`)
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+
+      const data = await res.json()
+      console.log(`[Users] Response:`, data)
+
+      if (data.success && data.data) {
+        setUsers(data.data)
+      } else {
+        setUsers([])
+      }
+    } catch (err) {
+      console.error("[Users] Error fetching data:", err)
+      setError(err instanceof Error ? err.message : "Error de conexión")
+      setUsers([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
-    async function fetchUsers() {
-      console.log(`[Users] Fetching from ${BACKEND}/api/v1/users`)
-      setLoading(true)
-      setError(null)
-
-      try {
-        const res = await fetch(`${BACKEND}/api/v1/users`)
-        console.log(`[Users] Response status: ${res.status}`)
-
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`)
-        }
-
-        const data = await res.json()
-        console.log(`[Users] Response:`, data)
-
-        if (data.success && data.data) {
-          setUsers(data.data)
-        } else {
-          setUsers([])
-        }
-      } catch (err) {
-        console.error("[Users] Error fetching data:", err)
-        setError(err instanceof Error ? err.message : "Error de conexión")
-        setUsers([])
-      } finally {
-        setLoading(false)
-      }
-    }
-
     fetchUsers()
-  }, [walletAddress])
+  }, [walletAddress, fetchUsers])
+
+  const handleDriverRegistered = () => {
+    setDialogOpen(false)
+    fetchUsers()
+  }
 
   const filteredUsers = users.filter(user =>
     user.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -118,6 +126,34 @@ export default function UsersPage() {
           <h1 className="text-2xl font-bold text-foreground">Usuarios</h1>
           <p className="text-muted-foreground">Gestionar conductores y usuarios de la wallet de flota</p>
         </div>
+
+        {/* Register Driver button — only visible for JEFE */}
+        {userRole === "JEFE" && walletAddress && (
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button id="register-driver-btn" className="gap-2">
+                <UserPlus className="h-4 w-4" />
+                Register Driver
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <UserPlus className="h-5 w-5 text-primary" />
+                  Register New Driver
+                </DialogTitle>
+                <DialogDescription>
+                  Add a new driver to your fleet. They will be linked to your manager account.
+                </DialogDescription>
+              </DialogHeader>
+              <RegisterDriverForm
+                managerPubKey={walletAddress}
+                onSuccess={handleDriverRegistered}
+                onCancel={() => setDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        )}
       </div>
 
       <Card>
@@ -185,7 +221,7 @@ export default function UsersPage() {
                       </td>
                       <td className="py-4">
                         <code className="text-xs font-mono text-muted-foreground">
-                          {user.stellarPubKey.slice(0, 12)}...{user.stellarPubKey.slice(-8)}
+                          {user.stellarPubKey?.slice(0, 12)}...{user.stellarPubKey?.slice(-8)}
                         </code>
                       </td>
                       <td className="py-4">
@@ -202,6 +238,11 @@ export default function UsersPage() {
                         }`}>
                           {user.role === "JEFE" ? "Jefe de Flota" : "Conductor"}
                         </span>
+                        {user.managerId && (
+                          <span className="ml-1.5 inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                            Managed
+                          </span>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/frontend/components/forms/RegisterDriverForm.tsx
+++ b/frontend/components/forms/RegisterDriverForm.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2, Key, User, AlertCircle, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { toast } from "sonner"
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://127.0.0.1:3001"
+
+/** Validates a Stellar Public Key: 56 chars, starts with G, base32. */
+function validateStellarKey(key: string): string | null {
+  if (!key) return "Stellar Public Key is required"
+  if (key.length !== 56) return `Must be exactly 56 characters (currently ${key.length})`
+  if (!key.startsWith("G")) return "Must start with the letter G"
+  if (!/^G[A-Z2-7]{55}$/.test(key))
+    return "Invalid format – only uppercase letters A-Z and digits 2-7 are allowed"
+  return null
+}
+
+interface RegisterDriverFormProps {
+  managerPubKey: string
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+export default function RegisterDriverForm({
+  managerPubKey,
+  onSuccess,
+  onCancel,
+}: RegisterDriverFormProps) {
+  const [name, setName] = useState("")
+  const [stellarPubKey, setStellarPubKey] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  // Validation states
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [keyError, setKeyError] = useState<string | null>(null)
+  const [touched, setTouched] = useState({ name: false, key: false })
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (touched.name) {
+      setNameError(value.trim() ? null : "Driver name is required")
+    }
+  }
+
+  const handleKeyChange = (value: string) => {
+    const upper = value.toUpperCase()
+    setStellarPubKey(upper)
+    if (touched.key) {
+      setKeyError(validateStellarKey(upper))
+    }
+  }
+
+  const handleNameBlur = () => {
+    setTouched((t) => ({ ...t, name: true }))
+    setNameError(name.trim() ? null : "Driver name is required")
+  }
+
+  const handleKeyBlur = () => {
+    setTouched((t) => ({ ...t, key: true }))
+    setKeyError(validateStellarKey(stellarPubKey))
+  }
+
+  const isValid = name.trim().length > 0 && validateStellarKey(stellarPubKey) === null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // Force‑touch for final validation display
+    setTouched({ name: true, key: true })
+    const nErr = name.trim() ? null : "Driver name is required"
+    const kErr = validateStellarKey(stellarPubKey)
+    setNameError(nErr)
+    setKeyError(kErr)
+    if (nErr || kErr) return
+
+    setSubmitting(true)
+    try {
+      const res = await fetch(`${BACKEND}/api/v1/users/register-driver`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-stellar-pubkey": managerPubKey,
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          stellarPubKey,
+        }),
+      })
+
+      const data = await res.json()
+
+      if (res.ok && data.success) {
+        toast.success("Driver registered successfully", {
+          description: `${name.trim()} has been added to your fleet.`,
+          icon: <CheckCircle2 className="h-4 w-4" />,
+        })
+        onSuccess()
+      } else {
+        toast.error("Failed to register driver", {
+          description: data.error || "Unknown error",
+        })
+      }
+    } catch (err) {
+      toast.error("Connection error", {
+        description: "Could not reach the server. Please try again.",
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* Driver Name */}
+      <div className="space-y-2">
+        <Label htmlFor="driver-name" className="flex items-center gap-1.5 text-sm font-medium">
+          <User className="h-4 w-4 text-muted-foreground" />
+          Driver Name
+        </Label>
+        <Input
+          id="driver-name"
+          placeholder="e.g. Carlos Hernández"
+          value={name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          onBlur={handleNameBlur}
+          disabled={submitting}
+          className={nameError && touched.name ? "border-destructive focus-visible:ring-destructive" : ""}
+        />
+        {nameError && touched.name && (
+          <p className="flex items-center gap-1 text-xs text-destructive">
+            <AlertCircle className="h-3 w-3" />
+            {nameError}
+          </p>
+        )}
+      </div>
+
+      {/* Stellar Public Key */}
+      <div className="space-y-2">
+        <Label htmlFor="driver-stellar-key" className="flex items-center gap-1.5 text-sm font-medium">
+          <Key className="h-4 w-4 text-muted-foreground" />
+          Stellar Public Key
+        </Label>
+        <Input
+          id="driver-stellar-key"
+          placeholder="G..."
+          value={stellarPubKey}
+          onChange={(e) => handleKeyChange(e.target.value)}
+          onBlur={handleKeyBlur}
+          disabled={submitting}
+          maxLength={56}
+          className={`font-mono text-sm ${
+            keyError && touched.key ? "border-destructive focus-visible:ring-destructive" : ""
+          }`}
+        />
+        <div className="flex items-center justify-between">
+          {keyError && touched.key ? (
+            <p className="flex items-center gap-1 text-xs text-destructive">
+              <AlertCircle className="h-3 w-3" />
+              {keyError}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              56-character Stellar address starting with G
+            </p>
+          )}
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {stellarPubKey.length}/56
+          </span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-3 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={submitting || !isValid}
+          className="min-w-[140px]"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Registering…
+            </>
+          ) : (
+            "Register Driver"
+          )}
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Closes #2

- Add managerId self-relation to User model in Prisma schema
- Add Stellar Public Key validation (56-char base32, starts with G)
- Create user.service.ts with JEFE role authorization logic
- Add POST /api/v1/users/register-driver endpoint
- Create RegisterDriverForm component with real-time validation
- Update usuarios page with JEFE-only registration dialog
- Auto-refresh driver table on successful registration
- Add 'Managed' badge for drivers linked to a manager
