### PR TITLE
feat: Implement Multi-Wallet Kit Integration to support Albedo, WalletConnect, and Mobile Clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ PORT=3001
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # ── SOROBAN SMART CONTRACT (Tank Registry) ──────────────────────────────────

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -7,12 +7,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Loader2, Wallet, User, Users } from 'lucide-react'
 import { useAuth, UserRole } from '@/providers/auth-provider'
 import { TankoLogoMinimal } from '@/components/logo'
+import { WalletConnectModal } from '@/components/wallet/wallet-connect-modal'
 
 export default function LoginPage() {
   const router = useRouter()
-  const { address, isConnected, isConnecting, connect, disconnect, setRole, role } = useAuth()
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
+  const { address, isConnected, isConnecting, disconnect, setRole, role } = useAuth()
+  const [modalOpen, setModalOpen] = useState(false)
 
   useEffect(() => {
     if (isConnected && address && role) {
@@ -23,19 +23,6 @@ export default function LoginPage() {
       }
     }
   }, [isConnected, address, role, router])
-
-  const handleWalletConnect = async () => {
-    setIsLoading(true)
-    setError('')
-
-    try {
-      await connect()
-    } catch (err) {
-      setError('Error al conectar wallet. Asegúrate de tener Freighter instalado.')
-    } finally {
-      setIsLoading(false)
-    }
-  }
 
   const handleRoleSelect = (selectedRole: UserRole) => {
     setRole(selectedRole)
@@ -53,7 +40,7 @@ export default function LoginPage() {
         <Card className="w-full max-w-md">
           <CardContent className="flex flex-col items-center justify-center py-12">
             <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
-            <p className="text-muted-foreground">Conectando con Freighter...</p>
+            <p className="text-muted-foreground">Conectando wallet...</p>
           </CardContent>
         </Card>
       </div>
@@ -142,24 +129,18 @@ export default function LoginPage() {
         </CardHeader>
         
         <CardContent className="space-y-4">
-          {error && (
-            <div className="mb-4 p-3 text-sm text-destructive bg-destructive/10 rounded-lg">
-              {error}
-            </div>
-          )}
-
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground text-center">
-              Conecta tu wallet Freighter para comenzar
+              Freighter, Albedo o WalletConnect en Stellar Testnet
             </p>
-            
+
             <Button
-              onClick={handleWalletConnect}
+              onClick={() => setModalOpen(true)}
               className="w-full"
-              disabled={isLoading}
+              disabled={isConnecting}
               size="lg"
             >
-              {isLoading ? (
+              {isConnecting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Conectando...
@@ -167,20 +148,13 @@ export default function LoginPage() {
               ) : (
                 <>
                   <Wallet className="mr-2 h-4 w-4" />
-                  Conectar con Freighter
+                  Conectar wallet
                 </>
               )}
             </Button>
           </div>
 
-          <div className="mt-6 p-4 rounded-lg bg-muted/50">
-            <h4 className="text-sm font-medium mb-2">Acerca de Freighter</h4>
-            <p className="text-xs text-muted-foreground">
-              Freighter es una wallet de Stellar que te permite interactuar con 
-              aplicaciones descentralizadas. Necesitarás crear una cuenta en 
-              Stellar Testnet para usar esta aplicación.
-            </p>
-          </div>
+          <WalletConnectModal open={modalOpen} onOpenChange={setModalOpen} />
         </CardContent>
       </Card>
     </div>

--- a/frontend/app/connect/page.tsx
+++ b/frontend/app/connect/page.tsx
@@ -1,13 +1,25 @@
 'use client'
 
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Fuel, Wallet, CheckCircle2, Loader2, ExternalLink, AlertCircle, Building2, Truck } from 'lucide-react'
+import { Fuel, Wallet, CheckCircle2, Loader2, AlertCircle, Building2, Truck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuth } from '@/providers/auth-provider'
+import { WalletConnectModal } from '@/components/wallet/wallet-connect-modal'
 
 export default function ConnectPage() {
-  const { isConnected, isConnecting, address, error, connect, disconnect, setRole } = useAuth()
+  const {
+    isConnected,
+    isConnecting,
+    address,
+    walletType,
+    walletLabel,
+    error,
+    disconnect,
+    setRole,
+  } = useAuth()
   const router = useRouter()
+  const [modalOpen, setModalOpen] = useState(false)
 
   const handleSelectRole = (role: 'JEFE' | 'CONDUCTOR') => {
     setRole(role)
@@ -23,7 +35,6 @@ export default function ConnectPage() {
       className="min-h-screen flex flex-col items-center justify-center px-4"
       style={{ background: 'linear-gradient(135deg, #0F1E35 0%, #1B2D4F 60%, #0F1E35 100%)' }}
     >
-      {/* Brand */}
       <div className="flex flex-col items-center gap-4 mb-12">
         <div
           className="flex h-20 w-20 items-center justify-center rounded-2xl shadow-2xl"
@@ -39,17 +50,15 @@ export default function ConnectPage() {
         </div>
       </div>
 
-      {/* Card */}
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/[0.04] p-8 backdrop-blur-sm shadow-2xl">
         {isConnected && address ? (
-          /* ── Connected state ── */
           <div className="flex flex-col items-center gap-6 text-center">
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-500/15 ring-2 ring-green-500/30">
               <CheckCircle2 className="h-8 w-8 text-green-400" />
             </div>
             <div>
               <p className="text-xs font-medium uppercase tracking-widest text-white/40 mb-2">
-                Wallet connected
+                Wallet connected{walletType ? ` · ${walletLabel}` : ''}
               </p>
               <p className="font-mono text-sm text-white/90 break-all">
                 {address.slice(0, 16)}…{address.slice(-16)}
@@ -98,13 +107,12 @@ export default function ConnectPage() {
               variant="ghost"
               size="sm"
               className="text-white/30 hover:text-white/50"
-              onClick={disconnect}
+              onClick={() => void disconnect()}
             >
               Disconnect Wallet
             </Button>
           </div>
         ) : (
-          /* ── Disconnected state ── */
           <div className="flex flex-col items-center gap-6 text-center">
             <div
               className="flex h-16 w-16 items-center justify-center rounded-full ring-2"
@@ -113,9 +121,9 @@ export default function ConnectPage() {
               <Wallet className="h-8 w-8" style={{ color: '#22c55e' }} />
             </div>
             <div>
-              <h2 className="text-xl font-semibold text-white">Connect your Freighter</h2>
+              <h2 className="text-xl font-semibold text-white">Connect your wallet</h2>
               <p className="mt-1 text-sm text-white/45">
-                Use the Freighter extension to access Tanko
+                Freighter, Albedo, or WalletConnect on mobile
               </p>
             </div>
 
@@ -131,27 +139,19 @@ export default function ConnectPage() {
               className="w-full font-semibold text-white"
               style={{ background: '#22c55e' }}
               disabled={isConnecting}
-              onClick={connect}
+              onClick={() => setModalOpen(true)}
             >
               {isConnecting ? (
                 <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Connecting…</>
               ) : (
-                <><Wallet className="mr-2 h-4 w-4" />Connect with Freighter</>
+                <><Wallet className="mr-2 h-4 w-4" />Connect Wallet</>
               )}
             </Button>
-
-            <a
-              href="https://freighter.app"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-white/35 hover:text-white/55 transition-colors"
-            >
-              Don't have Freighter? Install it here
-              <ExternalLink className="h-3 w-3" />
-            </a>
           </div>
         )}
       </div>
+
+      <WalletConnectModal open={modalOpen} onOpenChange={setModalOpen} />
 
       <p className="mt-10 text-xs text-white/20">
         Stellar Testnet · Trustless Work · Hack+ Alebrije CDMX 2026 🚛

--- a/frontend/components/wallet/wallet-button.tsx
+++ b/frontend/components/wallet/wallet-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useAuth } from '@/providers/auth-provider'
+import { WalletConnectModal } from '@/components/wallet/wallet-connect-modal'
 import { Wallet, ChevronDown, LogOut, Copy, CheckCheck, Loader2, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
@@ -11,8 +12,9 @@ interface WalletButtonProps {
 }
 
 export function WalletButton({ className }: WalletButtonProps) {
-  const { isConnected, isConnecting, address, connect, disconnect, error } = useAuth()
+  const { isConnected, isConnecting, address, walletLabel, disconnect } = useAuth()
   const [open, setOpen] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
   const [copied, setCopied] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -60,7 +62,7 @@ export function WalletButton({ className }: WalletButtonProps) {
           <div className="absolute right-0 top-full mt-2 w-72 rounded-xl border border-border bg-card p-3 shadow-xl z-50">
             {/* Full address */}
             <div className="mb-3 rounded-lg bg-muted/50 p-3">
-              <p className="text-xs font-medium text-muted-foreground mb-1">Connected wallet (Freighter)</p>
+              <p className="text-xs font-medium text-muted-foreground mb-1">Connected wallet ({walletLabel})</p>
               <p className="font-mono text-xs text-foreground break-all leading-relaxed">{address}</p>
             </div>
 
@@ -82,7 +84,7 @@ export function WalletButton({ className }: WalletButtonProps) {
                 View on Stellar Explorer
               </a>
               <button
-                onClick={() => { disconnect(); setOpen(false) }}
+                onClick={() => { void disconnect(); setOpen(false) }}
                 className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10"
               >
                 <LogOut className="h-4 w-4" />
@@ -95,21 +97,23 @@ export function WalletButton({ className }: WalletButtonProps) {
     )
   }
 
-  // ── Disconnected button ───────────────────────────────────────────────────
   return (
-    <Button
-      onClick={connect}
-      disabled={isConnecting}
-      size="sm"
-      className={`font-semibold text-white ${className}`}
-      style={{ background: '#F58220' }}
-    >
-      {isConnecting ? (
-        <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Connecting…</>
-      ) : (
-        <><Wallet className="mr-2 h-4 w-4" />Connect Wallet</>
-      )}
-    </Button>
+    <>
+      <Button
+        onClick={() => setModalOpen(true)}
+        disabled={isConnecting}
+        size="sm"
+        className={`font-semibold text-white ${className}`}
+        style={{ background: '#F58220' }}
+      >
+        {isConnecting ? (
+          <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Connecting…</>
+        ) : (
+          <><Wallet className="mr-2 h-4 w-4" />Connect Wallet</>
+        )}
+      </Button>
+      <WalletConnectModal open={modalOpen} onOpenChange={setModalOpen} />
+    </>
   )
 }
 

--- a/frontend/components/wallet/wallet-connect-modal.tsx
+++ b/frontend/components/wallet/wallet-connect-modal.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, ExternalLink } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useAuth } from "@/providers/auth-provider";
+import {
+  WALLET_OPTIONS,
+  type WalletType,
+} from "@/lib/wallet/types";
+import { isWalletAvailable } from "@/lib/wallet/stellar-wallet-service";
+
+interface WalletConnectModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function WalletConnectModal({ open, onOpenChange }: WalletConnectModalProps) {
+  const { connectWithWallet, isConnecting, error } = useAuth();
+  const [pendingId, setPendingId] = useState<WalletType | null>(null);
+
+  async function handleSelect(walletId: WalletType) {
+    if (!isWalletAvailable(walletId)) {
+      return;
+    }
+    setPendingId(walletId);
+    try {
+      await connectWithWallet(walletId);
+      onOpenChange(false);
+    } catch {
+      // error surfaced via auth context
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md border-white/10 bg-[#0F1E35] text-white">
+        <DialogHeader>
+          <DialogTitle className="text-white">Connect a wallet</DialogTitle>
+          <DialogDescription className="text-white/50">
+            Choose Freighter, Albedo, or WalletConnect for mobile Stellar wallets.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <p className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {WALLET_OPTIONS.map((wallet) => {
+            const available = isWalletAvailable(wallet.id);
+            const busy = isConnecting && pendingId === wallet.id;
+
+            return (
+              <button
+                key={wallet.id}
+                type="button"
+                disabled={!available || isConnecting}
+                onClick={() => handleSelect(wallet.id)}
+                className="group flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-white/[0.04] p-4 text-center transition-all hover:border-green-500/40 hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-white/5 ring-1 ring-white/10">
+                  {busy ? (
+                    <Loader2 className="h-6 w-6 animate-spin text-green-400" />
+                  ) : (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={wallet.iconUrl}
+                      alt=""
+                      width={40}
+                      height={40}
+                      className="h-10 w-10 rounded-lg object-contain"
+                    />
+                  )}
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">{wallet.name}</p>
+                  <p className="mt-1 text-[11px] leading-snug text-white/45">
+                    {wallet.requiresProjectId && !available
+                      ? "Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID"
+                      : wallet.description}
+                  </p>
+                </div>
+                {wallet.installUrl && (
+                  <a
+                    href={wallet.installUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="inline-flex items-center gap-1 text-[10px] text-white/35 hover:text-white/60"
+                  >
+                    Get {wallet.name}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <p className="text-center text-[11px] text-white/30">
+          Stellar Testnet · Soroban signing supported across providers
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/lib/wallet/kit.ts
+++ b/frontend/lib/wallet/kit.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit/sdk";
+import { Networks, type ModuleInterface } from "@creit.tech/stellar-wallets-kit/types";
+
+let initialized = false;
+
+export function getStellarNetwork(): Networks {
+  const net =
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK ||
+    process.env.STELLAR_NETWORK ||
+    "testnet";
+  if (net === "public" || net === "mainnet") {
+    return Networks.PUBLIC;
+  }
+  return Networks.TESTNET;
+}
+
+export function getNetworkPassphrase(): string {
+  return (
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ||
+    process.env.STELLAR_NETWORK_PASSPHRASE ||
+    Networks.TESTNET
+  );
+}
+
+export async function ensureKitInitialized(): Promise<void> {
+  if (initialized || typeof window === "undefined") {
+    return;
+  }
+
+  const { FreighterModule } = await import(
+    "@creit.tech/stellar-wallets-kit/modules/freighter"
+  );
+  const { AlbedoModule } = await import(
+    "@creit.tech/stellar-wallets-kit/modules/albedo"
+  );
+
+  const modules: ModuleInterface[] = [
+    new FreighterModule(),
+    new AlbedoModule(),
+  ];
+
+  const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID?.trim();
+  if (projectId) {
+    const { WalletConnectModule, WalletConnectTargetChain } = await import(
+      "@creit.tech/stellar-wallets-kit/modules/wallet-connect"
+    );
+    const origin = window.location.origin;
+    modules.push(
+      new WalletConnectModule({
+        projectId,
+        metadata: {
+          name: "Tanko",
+          description: "Fleet fuel management on Stellar",
+          url: origin,
+          icons: [`${origin}/icon.svg`],
+        },
+        allowedChains: [WalletConnectTargetChain.TESTNET],
+      }),
+    );
+  }
+
+  StellarWalletsKit.init({
+    modules,
+    network: getStellarNetwork(),
+  });
+
+  initialized = true;
+}
+
+export function isKitInitialized(): boolean {
+  return initialized;
+}

--- a/frontend/lib/wallet/stellar-wallet-service.ts
+++ b/frontend/lib/wallet/stellar-wallet-service.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit/sdk";
+import {
+  ensureKitInitialized,
+  getNetworkPassphrase,
+  isKitInitialized,
+} from "@/lib/wallet/kit";
+import type { WalletType } from "@/lib/wallet/types";
+import { WALLET_CONNECT_WALLET } from "@/lib/wallet/types";
+
+function walletConnectConfigured(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID?.trim());
+}
+
+export function isWalletAvailable(walletType: WalletType): boolean {
+  if (walletType === WALLET_CONNECT_WALLET) {
+    return walletConnectConfigured();
+  }
+  return true;
+}
+
+export async function connectWallet(walletType: WalletType): Promise<string> {
+  if (!isWalletAvailable(walletType)) {
+    throw new Error(
+      "WalletConnect is not configured. Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID.",
+    );
+  }
+
+  await ensureKitInitialized();
+  StellarWalletsKit.setWallet(walletType);
+  const { address } = await StellarWalletsKit.fetchAddress();
+
+  if (!address) {
+    throw new Error("No public key returned from the selected wallet.");
+  }
+
+  return address;
+}
+
+export async function restoreWalletSession(
+  walletType: WalletType,
+): Promise<string | null> {
+  if (!isWalletAvailable(walletType)) {
+    return null;
+  }
+
+  try {
+    await ensureKitInitialized();
+    StellarWalletsKit.setWallet(walletType);
+    const { address } = await StellarWalletsKit.getAddress();
+    return address || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function signWalletTransaction(
+  xdr: string,
+  address: string,
+): Promise<string> {
+  await ensureKitInitialized();
+  const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr, {
+    networkPassphrase: getNetworkPassphrase(),
+    address,
+  });
+  return signedTxXdr;
+}
+
+export async function disconnectWallet(): Promise<void> {
+  if (typeof window === "undefined" || !isKitInitialized()) {
+    return;
+  }
+  try {
+    await StellarWalletsKit.disconnect();
+  } catch (err) {
+    console.warn("[Tanko] Wallet disconnect:", err);
+  }
+}

--- a/frontend/lib/wallet/types.ts
+++ b/frontend/lib/wallet/types.ts
@@ -1,0 +1,50 @@
+import { ALBEDO_ID } from "@creit.tech/stellar-wallets-kit/modules/albedo";
+import { FREIGHTER_ID } from "@creit.tech/stellar-wallets-kit/modules/freighter";
+import { WALLET_CONNECT_ID } from "@creit.tech/stellar-wallets-kit/modules/wallet-connect";
+
+/** Wallet module ids used by @creit.tech/stellar-wallets-kit */
+export type WalletType = typeof FREIGHTER_ID | typeof ALBEDO_ID | typeof WALLET_CONNECT_ID;
+
+export const FREIGHTER_WALLET = FREIGHTER_ID as WalletType;
+export const ALBEDO_WALLET = ALBEDO_ID as WalletType;
+export const WALLET_CONNECT_WALLET = WALLET_CONNECT_ID as WalletType;
+
+export interface WalletOption {
+  id: WalletType;
+  name: string;
+  description: string;
+  iconUrl: string;
+  installUrl?: string;
+  requiresProjectId?: boolean;
+}
+
+export const WALLET_OPTIONS: WalletOption[] = [
+  {
+    id: FREIGHTER_WALLET,
+    name: "Freighter",
+    description: "Browser extension for Stellar",
+    iconUrl: "https://stellar.creit.tech/wallet-icons/freighter.png",
+    installUrl: "https://freighter.app",
+  },
+  {
+    id: ALBEDO_WALLET,
+    name: "Albedo",
+    description: "Web-based Stellar signer",
+    iconUrl: "https://stellar.creit.tech/wallet-icons/albedo.png",
+    installUrl: "https://albedo.link",
+  },
+  {
+    id: WALLET_CONNECT_WALLET,
+    name: "WalletConnect",
+    description: "Mobile wallets via QR or deep link",
+    iconUrl: "https://stellar.creit.tech/wallet-icons/walletconnect.png",
+    requiresProjectId: true,
+  },
+];
+
+export const STORAGE_KEYS = {
+  ADDRESS: "tanko_stellar_address",
+  WALLET_TYPE: "tanko_wallet_type",
+  ROLE: "tanko_user_role",
+  USER_ID: "tanko_user_id",
+} as const;

--- a/frontend/providers/auth-provider.tsx
+++ b/frontend/providers/auth-provider.tsx
@@ -5,212 +5,247 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useCallback,
   ReactNode,
 } from "react";
+import {
+  connectWallet,
+  disconnectWallet,
+  restoreWalletSession,
+  signWalletTransaction,
+} from "@/lib/wallet/stellar-wallet-service";
+import {
+  STORAGE_KEYS,
+  FREIGHTER_WALLET,
+  type WalletType,
+} from "@/lib/wallet/types";
 
 export type UserRole = "CONDUCTOR" | "JEFE" | null;
 
+function parseStoredWalletType(raw: string | null): WalletType | null {
+  if (
+    raw === "freighter" ||
+    raw === "albedo" ||
+    raw === "wallet_connect"
+  ) {
+    return raw;
+  }
+  return null;
+}
+
+function walletLabel(walletType: WalletType | null): string {
+  switch (walletType) {
+    case "freighter":
+      return "Freighter";
+    case "albedo":
+      return "Albedo";
+    case "wallet_connect":
+      return "WalletConnect";
+    default:
+      return "Stellar";
+  }
+}
+
 interface AuthState {
   address: string | null;
+  walletType: WalletType | null;
   isConnected: boolean;
   isConnecting: boolean;
   error: string | null;
-  freighterInstalled: boolean;
   role: UserRole;
-  setRole: (role: UserRole) => void;
   userId: string | null;
-  setUserId: (id: string | null) => void;
 }
 
 interface AuthContextType extends AuthState {
+  /** Unified alias for `address` (issue #31) */
+  walletAddress: string | null;
+  setRole: (role: UserRole) => void;
+  setUserId: (id: string | null) => void;
+  connectWithWallet: (walletType: WalletType) => Promise<void>;
+  /** @deprecated Prefer connectWithWallet; defaults to Freighter */
   connect: () => Promise<void>;
-  disconnect: () => void;
+  signTransaction: (xdr: string) => Promise<string>;
+  disconnect: () => Promise<void>;
+  walletLabel: string;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const STORAGE_KEYS = {
-  ADDRESS: "tanko_stellar_address",
-  ROLE: "tanko_user_role",
-  USER_ID: "tanko_user_id",
-};
-
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({
     address: null,
+    walletType: null,
     isConnected: false,
     isConnecting: false,
     error: null,
-    freighterInstalled: false,
     role: null,
     userId: null,
-    setRole: (role: UserRole) => setState(prev => ({ ...prev, role })),
-    setUserId: (id: string | null) => setState(prev => ({ ...prev, userId: id })),
   });
+
+  const persistSession = useCallback(
+    (address: string, walletType: WalletType) => {
+      localStorage.setItem(STORAGE_KEYS.ADDRESS, address);
+      localStorage.setItem(STORAGE_KEYS.WALLET_TYPE, walletType);
+    },
+    [],
+  );
+
+  const clearWalletSession = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEYS.ADDRESS);
+    localStorage.removeItem(STORAGE_KEYS.WALLET_TYPE);
+    localStorage.removeItem(STORAGE_KEYS.ROLE);
+    localStorage.removeItem(STORAGE_KEYS.USER_ID);
+  }, []);
 
   useEffect(() => {
     async function restore() {
-      try {
-        const freighter = await import("@stellar/freighter-api");
+      const storedAddress = localStorage.getItem(STORAGE_KEYS.ADDRESS);
+      const storedWalletType = parseStoredWalletType(
+        localStorage.getItem(STORAGE_KEYS.WALLET_TYPE),
+      );
+      const storedRole = localStorage.getItem(STORAGE_KEYS.ROLE) as UserRole;
+      const storedUserId = localStorage.getItem(STORAGE_KEYS.USER_ID);
 
-        const { isConnected } = await freighter.isConnected();
-        const storedAddress = localStorage.getItem(STORAGE_KEYS.ADDRESS);
-        const storedRole = localStorage.getItem(STORAGE_KEYS.ROLE) as UserRole;
-        const storedUserId = localStorage.getItem(STORAGE_KEYS.USER_ID);
+      if (!storedAddress) {
+        return;
+      }
 
-        if (!isConnected) {
-          if (storedAddress) {
-            setState((prev) => ({
-              ...prev,
-              address: storedAddress,
-              isConnected: true,
-              freighterInstalled: false,
-              role: storedRole,
-              userId: storedUserId,
-              setRole: prev.setRole,
-              setUserId: prev.setUserId,
-            }));
-          }
-          return;
-        }
-
-        setState((prev) => ({ ...prev, freighterInstalled: true }));
-
-        const { isAllowed } = await freighter.isAllowed();
-        if (isAllowed) {
-          const { address, error } = await freighter.getAddress();
-          if (!error && address) {
-            localStorage.setItem(STORAGE_KEYS.ADDRESS, address);
-            setState((prev) => ({
-              address,
-              isConnected: true,
-              isConnecting: false,
-              error: null,
-              freighterInstalled: true,
-              role: storedRole,
-              userId: storedUserId,
-              setRole: prev.setRole,
-              setUserId: prev.setUserId,
-            }));
-          }
-        } else if (storedAddress) {
-          setState((prev) => ({
-            ...prev,
-            address: storedAddress,
+      if (storedWalletType) {
+        const liveAddress = await restoreWalletSession(storedWalletType);
+        if (liveAddress) {
+          persistSession(liveAddress, storedWalletType);
+          setState({
+            address: liveAddress,
+            walletType: storedWalletType,
             isConnected: true,
-            freighterInstalled: true,
+            isConnecting: false,
+            error: null,
             role: storedRole,
             userId: storedUserId,
-            setRole: prev.setRole,
-            setUserId: prev.setUserId,
-          }));
+          });
+          return;
         }
-      } catch (err) {
-        console.error("[Tanko] Freighter init error:", err);
       }
+
+      // Fallback: show last known address until user reconnects or disconnects
+      setState({
+        address: storedAddress,
+        walletType: storedWalletType,
+        isConnected: true,
+        isConnecting: false,
+        error: null,
+        role: storedRole,
+        userId: storedUserId,
+      });
     }
 
-    restore();
-  }, []);
+    restore().catch((err) => {
+      console.error("[Tanko] Wallet restore error:", err);
+    });
+  }, [persistSession]);
 
-  const connect = async () => {
-    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
-    try {
-      const freighter = await import("@stellar/freighter-api");
-
-      const { isConnected } = await freighter.isConnected();
-      if (!isConnected) {
+  const connectWithWallet = useCallback(
+    async (walletType: WalletType) => {
+      setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+      try {
+        const address = await connectWallet(walletType);
+        persistSession(address, walletType);
         setState((prev) => ({
           ...prev,
-          isConnecting: false,
-          freighterInstalled: false,
-          error:
-            "Freighter is not installed. Install it at freighter.app and reload the page.",
-          setRole: prev.setRole,
-          setUserId: prev.setUserId,
-        }));
-        return;
-      }
-
-      const { address, error } = await freighter.requestAccess();
-
-      if (error) {
-        setState((prev) => ({
-          ...prev,
-          isConnecting: false,
-          error: `Freighter denied access: ${error}`,
-          setRole: prev.setRole,
-          setUserId: prev.setUserId,
-        }));
-        return;
-      }
-
-      if (address) {
-        localStorage.setItem(STORAGE_KEYS.ADDRESS, address);
-        setState((prev) => ({
           address,
+          walletType,
           isConnected: true,
           isConnecting: false,
           error: null,
-          freighterInstalled: true,
-          role: prev.role,
-          userId: prev.userId,
-          setRole: prev.setRole,
-          setUserId: prev.setUserId,
         }));
-        console.log(`[Tanko] ✅ Freighter connected: ${address}`);
+        console.log(
+          `[Tanko] ✅ ${walletLabel(walletType)} connected: ${address}`,
+        );
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Could not connect. Unlock your wallet and try again.";
+        setState((prev) => ({
+          ...prev,
+          isConnecting: false,
+          error: message,
+        }));
       }
-    } catch (err: any) {
-      setState((prev) => ({
-        ...prev,
-        isConnecting: false,
-        error:
-          err?.message || "Connection error. Make sure Freighter is unlocked.",
-        setRole: prev.setRole,
-        setUserId: prev.setUserId,
-      }));
-    }
-  };
+    },
+    [persistSession],
+  );
 
-  const disconnect = () => {
-    localStorage.removeItem(STORAGE_KEYS.ADDRESS);
-    localStorage.removeItem(STORAGE_KEYS.ROLE);
-    localStorage.removeItem(STORAGE_KEYS.USER_ID);
-    setState((prev) => ({
-      ...prev,
+  const connect = useCallback(async () => {
+    await connectWithWallet(FREIGHTER_WALLET);
+  }, [connectWithWallet]);
+
+  const signTransaction = useCallback(
+    async (xdr: string): Promise<string> => {
+      if (!state.address) {
+        throw new Error("No wallet connected.");
+      }
+      try {
+        return await signWalletTransaction(xdr, state.address);
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error ? err.message : "Transaction signing failed.";
+        setState((prev) => ({ ...prev, error: message }));
+        throw err;
+      }
+    },
+    [state.address],
+  );
+
+  const disconnect = useCallback(async () => {
+    await disconnectWallet();
+    clearWalletSession();
+    setState({
       address: null,
+      walletType: null,
       isConnected: false,
       isConnecting: false,
       error: null,
       role: null,
       userId: null,
-      setRole: prev.setRole,
-      setUserId: prev.setUserId,
-    }));
+    });
     console.log("[Tanko] Wallet disconnected");
-  };
+    if (typeof window !== "undefined") {
+      window.location.href = "/connect";
+    }
+  }, [clearWalletSession]);
 
-  const setRole = (role: UserRole) => {
+  const setRole = useCallback((role: UserRole) => {
     if (role) {
       localStorage.setItem(STORAGE_KEYS.ROLE, role);
     } else {
       localStorage.removeItem(STORAGE_KEYS.ROLE);
     }
     setState((prev) => ({ ...prev, role }));
-  };
+  }, []);
 
-  const setUserId = (userId: string | null) => {
+  const setUserId = useCallback((userId: string | null) => {
     if (userId) {
       localStorage.setItem(STORAGE_KEYS.USER_ID, userId);
     } else {
       localStorage.removeItem(STORAGE_KEYS.USER_ID);
     }
     setState((prev) => ({ ...prev, userId }));
-  };
+  }, []);
 
   return (
     <AuthContext.Provider
-      value={{ ...state, connect, disconnect, setRole, setUserId }}
+      value={{
+        ...state,
+        walletAddress: state.address,
+        connectWithWallet,
+        connect,
+        signTransaction,
+        disconnect,
+        setRole,
+        setUserId,
+        walletLabel: walletLabel(state.walletType),
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/providers/wallet-provider.tsx
+++ b/frontend/providers/wallet-provider.tsx
@@ -1,3 +1,4 @@
+/** @deprecated Use AuthProvider + @/lib/wallet instead (issue #31). */
 'use client'
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'


### PR DESCRIPTION
Closes #31

## Summary

- Replaces the Freighter-only auth flow with `@creit.tech/stellar-wallets-kit`, supporting Freighter, Albedo, and WalletConnect (mobile via QR/deep link when `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` is set).
- Adds a wallet selection modal on `/connect`, login, and the header wallet button, with provider icons and clear disabled state when WalletConnect is not configured.
- Introduces a unified auth surface: `walletAddress`, `walletType`, `isConnected`, plus `connectWithWallet()`, `signTransaction()`, and async `disconnect()` that clears session storage and redirects to `/connect`.
- Persists `tanko_wallet_type` alongside the existing Stellar address so sessions restore through the correct provider on reload.

## Implementation notes

- New wallet layer under `frontend/lib/wallet/` (`kit.ts`, `stellar-wallet-service.ts`, `types.ts`).
- `AuthProvider` is the single source of truth; legacy `wallet-provider.tsx` is marked deprecated.
- `.env.example` documents `NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE`, and `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`.

## Test plan (For reviewer -  Please make test the following and give feedback if they cleared or did not)

- [ ] Open `/connect` → **Connect Wallet** → modal shows Freighter, Albedo, and WalletConnect (WC greyed out without project ID).
- [ ] Connect with Freighter on Stellar Testnet; confirm address and provider label appear before role selection.
- [ ] Connect with Albedo on Testnet; confirm same unified state and session restore after page reload.
- [ ] With `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` set, pair a mobile Stellar wallet via QR/deep link on a mobile viewport.
- [ ] Disconnect clears localStorage and returns to `/connect` with a clean UI.
- [ ] Call `signTransaction(xdr)` from a Soroban escrow flow (when wired) and confirm signing works for at least two providers.
- [ ] Browser console shows no unhandled wallet promise rejections during connect, sign, or disconnect.
