### PR TITLE
implement user onboarding flow for Fleet Managers and Drivers

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "@prisma/client": "^7.7.0",
     "@stellar/stellar-sdk": "^13.3.0",
     "axios": "^1.6.7",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.18.2",
@@ -45,6 +46,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^30.0.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   id            String    @id @default(uuid())
   name          String
   email         String    @unique
+  passwordHash  String?
   phone         String?
   stellarPubKey String?   @unique
   avalancheCChainAddress String? @unique
@@ -28,6 +29,9 @@ model User {
   managerRequests FundRequest[] @relation("manager")
   fuelLogs        FuelLog[]
   driverKyc       DriverKyc?
+  managerProfile  ManagerProfile?
+  driverProfile   DriverProfile?
+  fuelWallet      FuelWallet?
   manager         User?         @relation("ManagerDrivers", fields: [managerId], references: [id])
   drivers         User[]        @relation("ManagerDrivers")
 
@@ -52,6 +56,33 @@ model DriverKyc {
   updatedAt       DateTime @updatedAt
 
   @@index([status])
+}
+
+model ManagerProfile {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  documentId  String   @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model DriverProfile {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  documentId  String   @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model FuelWallet {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  balance     Float    @default(0.00)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Unit {

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { authService } from '../services/auth.service.js';
+
+export class AuthController {
+  async register(req: Request, res: Response): Promise<void> {
+    try {
+      const { name, email, password, phone, role, documentId } = req.body;
+
+      // Validate required fields
+      if (!email || !password || !name || !role || !documentId) {
+        res.status(400).json({ error: 'Missing mandatory fields (email, password, name, role, documentId).' });
+        return;
+      }
+
+      if (role !== 'MANAGER' && role !== 'DRIVER') {
+        res.status(400).json({ error: 'Invalid role. Must be MANAGER or DRIVER.' });
+        return;
+      }
+
+      const user = await authService.register({
+        name,
+        email,
+        password,
+        phone,
+        role,
+        documentId,
+      });
+
+      res.status(201).json({
+        message: 'Registration successful',
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role,
+        },
+      });
+    } catch (error) {
+      console.error('[Auth] Registration error:', error);
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Failed to register',
+      });
+    }
+  }
+}
+
+export const authController = new AuthController();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import configRoutes from "./routes/config.routes.js";
 import stationRoutes from "./routes/station.routes.js";
 import kycRoutes from "./routes/kyc.routes.js";
 import exportRoutes from "./routes/export.routes.js";
+import authRoutes from "./routes/auth.routes.js";
 import { logger } from "./utils/logger.js";
 import { oracleCronService } from "./services/oracle-cron.service.js";
 import fs from "fs";
@@ -60,6 +61,7 @@ app.get("/api/v1/openapi.json", (req, res) => {
 });
 
 app.use("/api/v1", escrowRoutes);
+app.use("/api/v1", authRoutes);
 app.use("/api/v1", walletRoutes);
 app.use("/api/v1", fundsRoutes);
 app.use("/api/v1", statsRoutes);

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { authController } from '../controllers/auth.controller.js';
+
+const router = Router();
+
+router.post('/auth/register', (req, res) => authController.register(req, res));
+
+export default router;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,0 +1,88 @@
+import prisma from '../db/prisma.js';
+import bcrypt from 'bcryptjs';
+
+export interface RegisterDTO {
+  name: string;
+  email: string;
+  password?: string;
+  phone?: string;
+  role: 'MANAGER' | 'DRIVER';
+  documentId: string;
+}
+
+export class AuthService {
+  async register(data: RegisterDTO) {
+    const { name, email, password, phone, role, documentId } = data;
+
+    // Check if user already exists with email
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (existingUser) {
+      throw new Error('User with this email already exists.');
+    }
+
+    // Check if document ID already used for this role
+    if (role === 'MANAGER') {
+      const existingDoc = await prisma.managerProfile.findUnique({
+        where: { documentId },
+      });
+      if (existingDoc) {
+        throw new Error('Manager document ID already registered.');
+      }
+    } else if (role === 'DRIVER') {
+      const existingDoc = await prisma.driverProfile.findUnique({
+        where: { documentId },
+      });
+      if (existingDoc) {
+        throw new Error('Driver document ID already registered.');
+      }
+    }
+
+    const passwordHash = password ? await bcrypt.hash(password, 10) : null;
+
+    // Transaction to ensure atomicity
+    return prisma.$transaction(async (tx) => {
+      // 1. Create User
+      const user = await tx.user.create({
+        data: {
+          name,
+          email,
+          passwordHash,
+          phone,
+          role,
+        },
+      });
+
+      // 2. Role-specific creation
+      if (role === 'MANAGER') {
+        await tx.managerProfile.create({
+          data: {
+            userId: user.id,
+            documentId,
+          },
+        });
+
+        // Initialize Monedero (FuelWallet)
+        await tx.fuelWallet.create({
+          data: {
+            userId: user.id,
+            balance: 0.00,
+          },
+        });
+      } else if (role === 'DRIVER') {
+        await tx.driverProfile.create({
+          data: {
+            userId: user.id,
+            documentId,
+          },
+        });
+      }
+
+      return user;
+    });
+  }
+}
+
+export const authService = new AuthService();

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import app from '../src/index';
+import prisma from '../src/db/prisma';
+
+describe('Auth API Endpoints', () => {
+  beforeAll(async () => {
+    await prisma.driverProfile.deleteMany();
+    await prisma.managerProfile.deleteMany();
+    await prisma.fuelWallet.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  describe('POST /api/v1/auth/register', () => {
+    it('should register a MANAGER and create a FuelWallet with 0 balance', async () => {
+      const payload = {
+        name: 'Manager Test',
+        email: 'manager@test.com',
+        password: 'Password123',
+        phone: '1234567890',
+        role: 'MANAGER',
+        documentId: 'GOV-ID-123',
+      };
+
+      const res = await request(app).post('/api/v1/auth/register').send(payload);
+      
+      expect(res.status).toBe(201);
+      expect(res.body.user).toHaveProperty('id');
+      expect(res.body.user.role).toBe('MANAGER');
+
+      // Verify DB entries
+      const managerUser = await prisma.user.findUnique({ where: { email: payload.email } });
+      expect(managerUser).not.toBeNull();
+      expect(managerUser?.passwordHash).not.toBeNull();
+      expect(managerUser?.passwordHash).not.toBe(payload.password); // Should be hashed
+
+      const profile = await prisma.managerProfile.findUnique({ where: { documentId: payload.documentId } });
+      expect(profile).not.toBeNull();
+      expect(profile?.userId).toBe(managerUser?.id);
+
+      const wallet = await prisma.fuelWallet.findUnique({ where: { userId: managerUser?.id } });
+      expect(wallet).not.toBeNull();
+      expect(wallet?.balance).toBe(0);
+    });
+
+    it('should register a DRIVER without creating a FuelWallet', async () => {
+      const payload = {
+        name: 'Driver Test',
+        email: 'driver@test.com',
+        password: 'Password123',
+        phone: '0987654321',
+        role: 'DRIVER',
+        documentId: 'DRV-LIC-123',
+      };
+
+      const res = await request(app).post('/api/v1/auth/register').send(payload);
+      
+      expect(res.status).toBe(201);
+      expect(res.body.user.role).toBe('DRIVER');
+
+      // Verify DB entries
+      const driverUser = await prisma.user.findUnique({ where: { email: payload.email } });
+      expect(driverUser).not.toBeNull();
+
+      const profile = await prisma.driverProfile.findUnique({ where: { documentId: payload.documentId } });
+      expect(profile).not.toBeNull();
+
+      const wallet = await prisma.fuelWallet.findUnique({ where: { userId: driverUser?.id } });
+      expect(wallet).toBeNull(); // Drivers should not have their own fuel wallet
+    });
+
+    it('should fail registration with duplicate email', async () => {
+      const payload = {
+        name: 'Another Manager',
+        email: 'manager@test.com',
+        password: 'Password123',
+        phone: '1231231234',
+        role: 'MANAGER',
+        documentId: 'GOV-ID-999',
+      };
+
+      const res = await request(app).post('/api/v1/auth/register').send(payload);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('already exists');
+    });
+
+    it('should fail registration with duplicate document ID for the same role', async () => {
+      const payload = {
+        name: 'Manager Duplicate Doc',
+        email: 'manager2@test.com',
+        password: 'Password123',
+        phone: '1231231234',
+        role: 'MANAGER',
+        documentId: 'GOV-ID-123', // Same as first test
+      };
+
+      const res = await request(app).post('/api/v1/auth/register').send(payload);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('already registered');
+    });
+  });
+});


### PR DESCRIPTION
```markdown

**Close #62 
```
**Summary of the issue**
Tanko requires a self-serve onboarding mechanism for fleet operators and drivers to scale seamlessly without manual database seeding. A clear role separation and identity verification at registration is critical for escrow security, regulatory compliance, and proper fuel allocation.

**Root cause**
Currently, the system lacks a dedicated onboarding/registration interface to securely collect credentials and identity documents, differentiate roles, and properly scaffold the necessary financial resources (like an electronic fuel vault) for managers upon sign up. 
----
**Solution implemented**
Implemented a full user registration API endpoint (`POST /api/v1/auth/register`) that robustly handles core authentication credential collection, identity document uniqueness, role assignments (`MANAGER` and `DRIVER`), and automatic Monedero (FuelWallet) creation for Managers. 

**Key changes made**
- **Schema Updates**: Appended `passwordHash` to the `User` model. Created `ManagerProfile` and `DriverProfile` models to enforce role-specific unique `documentId` constraints. Created `FuelWallet` model linked uniquely to Manager users.
- **Auth Flow**: Added `auth.controller.ts`, `auth.service.ts`, and `auth.routes.ts` incorporating `bcryptjs` for secure password hashing.
- **Monedero Initialization**: Automated the creation of a `FuelWallet` initialized with a `0.00` balance upon successful MANAGER registration in a Prisma database transaction, ensuring atomicity.
- **Driver Exemption**: Structured the service logic so that DRIVER registrations completely bypass wallet creation, preparing them for future fleet assignments. 
- **Validation & Integration Testing**: Set up extensive integration tests in `auth.test.ts` to ensure password hashing integrity, role assignment constraints, unique document validations, and exact DB wallet scaffolding.
---
**Any trade-offs or considerations**
- As discussed in the scope of v1, automated OCR processing for ID verifications is left out; the system currently stores the reference document IDs directly. This relies on an administrative/manual pipeline for KYC approval later.
- Implemented `bcryptjs` for simple and portable password hashing.

**Testing steps (how to verify the fix)**
1. Ensure your database is running and `npm install` has been freshly executed.
2. Run Prisma migrations: `npx prisma db push` or `npx prisma migrate dev` to update your database schema.
3. Start the dev server using `npm run dev`.
4. Use an API client (like Postman or cURL) to make a `POST` request to `/api/v1/auth/register` using a MANAGER role payload.
5. Verify in the database (or via Prisma Studio `npm run db:studio`) that the newly created Manager account has an associated `FuelWallet` record initialized with a `0.00` balance.
6. Verify via a similar `DRIVER` registration request that no `FuelWallet` is created for them.
7. Run tests explicitly targeting the auth suite: `npm run test` or `npx jest tests/auth.test.ts`.
```
Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch.
Thank you!

*** 
