### PR TITLE
Feat/unidades resilient retries

### DIFF
--- a/frontend/__tests__/export-units-csv.test.ts
+++ b/frontend/__tests__/export-units-csv.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { safeCSVField, exportUnitsToCSV, type Unit } from '@/lib/csv/export-units'
+
+describe('Units CSV Export', () => {
+  describe('safeCSVField', () => {
+    it('returns plain fields unchanged', () => {
+      expect(safeCSVField('Toyota')).toBe('Toyota')
+    })
+
+    it('returns empty string for null/undefined', () => {
+      expect(safeCSVField(null)).toBe('')
+      expect(safeCSVField(undefined)).toBe('')
+    })
+
+    it('wraps fields containing commas in double quotes', () => {
+      expect(safeCSVField('A, B')).toBe('"A, B"')
+    })
+
+    it('escapes double quotes inside fields', () => {
+      expect(safeCSVField('He said "hi"')).toBe('"He said ""hi"""')
+    })
+
+    it('wraps fields containing newlines in double quotes', () => {
+      expect(safeCSVField('line1\nline2')).toBe('"line1\nline2"')
+    })
+
+    it('prefixes fields starting with = (formula guard)', () => {
+      expect(safeCSVField('=1+1')).toBe("'=1+1")
+    })
+
+    it('prefixes fields starting with + (formula guard)', () => {
+      expect(safeCSVField('+add')).toBe("'+add")
+    })
+
+    it('prefixes fields starting with - (formula guard)', () => {
+      expect(safeCSVField('-subtract')).toBe("'-subtract")
+    })
+
+    it('prefixes fields starting with @ (formula guard)', () => {
+      expect(safeCSVField('@mention')).toBe("'@mention")
+    })
+
+    it('prefixes fields with leading spaces before formula trigger', () => {
+      expect(safeCSVField('  =1+1')).toBe("'  =1+1")
+    })
+
+    it('handles both formula guard AND comma/quote escaping simultaneously', () => {
+      expect(safeCSVField('=1+1,"test"')).toBe('"\'=1+1,""test"""')
+    })
+
+    it('handles single-character trigger fields without double-apostrophe', () => {
+      expect(safeCSVField('-')).toBe("'-")
+      expect(safeCSVField('@')).toBe("'@")
+    })
+
+    it('prefixes fields starting with tab (formula guard)', () => {
+      expect(safeCSVField('\t=formula')).toBe("'\t=formula")
+    })
+
+    it('prefixes fields starting with carriage return (formula guard)', () => {
+      expect(safeCSVField('\r=formula')).toBe("'\r=formula")
+    })
+
+    it('does not prefix fields that have formula chars mid-string', () => {
+      expect(safeCSVField('hello =world')).toBe('hello =world')
+    })
+
+    it('does not prefix fields starting with regular chars', () => {
+      expect(safeCSVField('123')).toBe('123')
+      expect(safeCSVField('abc')).toBe('abc')
+    })
+  })
+
+  describe('exportUnitsToCSV', () => {
+    let downloadSpy: ReturnType<typeof vi.fn>
+    let createElementSpy: ReturnType<typeof vi.fn>
+    let appendChildSpy: ReturnType<typeof vi.fn>
+    let removeChildSpy: ReturnType<typeof vi.fn>
+    let clickSpy: ReturnType<typeof vi.fn>
+    let revokeObjectURLSpy: ReturnType<typeof vi.fn>
+    let createdBlob: Blob | null = null
+
+    const mockUnits: Unit[] = [
+      {
+        id: 'unit-1',
+        make: 'Toyota',
+        model: 'Hilux',
+        year: 2023,
+        plates: 'ABC-123',
+        isActive: true,
+        permitNumber: 'P-001',
+        permitExpiry: '2025-06-15',
+        user: { name: 'Juan Pérez' },
+      },
+      {
+        id: 'unit-2',
+        make: 'Nissan',
+        model: 'NP300',
+        year: 2022,
+        plates: 'XYZ-789',
+        isActive: false,
+        user: undefined,
+      },
+    ]
+
+    beforeEach(() => {
+      createdBlob = null
+      clickSpy = vi.fn()
+      revokeObjectURLSpy = vi.fn()
+      appendChildSpy = vi.fn()
+      removeChildSpy = vi.fn()
+
+      downloadSpy = vi.fn((url: string) => {
+        // Extract blob from object URL by reading the mock
+        return url
+      })
+
+      createElementSpy = vi.fn(() => ({
+        tag: 'a',
+        href: '',
+        download: '',
+        click: clickSpy,
+      }))
+
+      vi.stubGlobal('document', {
+        createElement: createElementSpy,
+        body: {
+          appendChild: appendChildSpy,
+          removeChild: removeChildSpy,
+        },
+      })
+
+      vi.stubGlobal('URL', {
+        createObjectURL: (blob: Blob) => {
+          createdBlob = blob
+          return 'blob:mock-url'
+        },
+        revokeObjectURL: revokeObjectURLSpy,
+      })
+    })
+
+    it('generates CSV with correct headers and data rows', () => {
+      exportUnitsToCSV(mockUnits)
+
+      expect(createdBlob).not.toBeNull()
+      expect(createdBlob!.type).toBe('text/csv;charset=utf-8')
+
+      // Verify the blob content by reading it
+      const reader = new FileReader()
+      // Since we can't easily read blob content in test, verify structure
+      expect(createdBlob).toBeDefined()
+    })
+
+    it('includes BOM prefix for Excel compatibility', async () => {
+      exportUnitsToCSV(mockUnits)
+
+      // Read the blob content
+      const text = await createdBlob!.text()
+      // BOM is \uFEFF — check the file starts with it
+      expect(text.charCodeAt(0)).toBe(0xFEFF)
+    })
+
+    it('contains all expected column headers', async () => {
+      exportUnitsToCSV(mockUnits)
+
+      const text = await createdBlob!.text()
+      const lines = text.split('\n')
+      // First line after BOM should be headers (BOM + header text)
+      const headerLine = lines[0].replace(/^\uFEFF/, '')
+      expect(headerLine).toBe(
+        'ID,Marca,Modelo,Año,Placas,Conductor,No. Permiso,Vencimiento Permiso,Estado'
+      )
+    })
+
+    it('maps unit data to correct CSV columns', async () => {
+      exportUnitsToCSV([mockUnits[0]])
+
+      const text = await createdBlob!.text()
+      const lines = text.replace(/^\uFEFF/, '').split('\n')
+      const dataRow = lines[1]
+
+      expect(dataRow).toContain('unit-1')
+      expect(dataRow).toContain('Toyota')
+      expect(dataRow).toContain('Hilux')
+      expect(dataRow).toContain('2023')
+      expect(dataRow).toContain('ABC-123')
+      expect(dataRow).toContain('Juan Pérez')
+      expect(dataRow).toContain('P-001')
+      expect(dataRow).toContain('2025-06-15')
+      expect(dataRow).toContain('Activo')
+    })
+
+    it('handles optional fields gracefully (undefined user)', async () => {
+      exportUnitsToCSV([mockUnits[1]])
+
+      const text = await createdBlob!.text()
+      const lines = text.replace(/^\uFEFF/, '').split('\n')
+      const dataRow = lines[1]
+      const columns = dataRow.split(',')
+
+      // Conductor (index 5) should be empty
+      expect(columns[5]).toBe('')
+      // No. Permiso (index 6) should be empty
+      expect(columns[6]).toBe('')
+      // Estado should be Inactivo
+      expect(columns[8]).toBe('Inactivo')
+    })
+
+    it('triggers file download with correct filename', () => {
+      exportUnitsToCSV(mockUnits)
+
+      const anchorEl = createElementSpy.mock.results[0].value
+      expect(anchorEl.download).toMatch(/^flota_\d{4}-\d{2}-\d{2}\.csv$/)
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it('cleans up object URL after download', () => {
+      exportUnitsToCSV(mockUnits)
+
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url')
+    })
+
+    it('neutralizes formula-injection in exported data', async () => {
+      const maliciousUnit: Unit[] = [
+        {
+          id: 'unit-mal',
+          make: 'Toyota',
+          model: 'Corolla',
+          plates: '=1+1',
+          isActive: true,
+          user: { name: '=HYPERLINK("http://evil.com","click")' },
+        },
+      ]
+
+      exportUnitsToCSV(maliciousUnit)
+
+      const text = await createdBlob!.text()
+      const lines = text.replace(/^\uFEFF/, '').split('\n')
+      const dataRow = lines[1]
+
+      // Placas field: formula guard adds apostrophe, no comma/quote so no wrapping
+      expect(dataRow).toContain("'=1+1")
+      expect(dataRow).not.toMatch(/,=1[+,]/)
+
+      // Conductor field: formula guard adds apostrophe, then comma+quote triggers CSV wrapping
+      // The field becomes "'=HYPERLINK(""http://evil.com"",""click"")" — a properly quoted CSV cell
+      // Verify the raw CSV doesn't contain a bare =HYPERLINK formula
+      expect(dataRow).not.toMatch(/,=HYPERLINK/)
+    })
+  })
+})

--- a/frontend/app/dashboard/unidades/page.tsx
+++ b/frontend/app/dashboard/unidades/page.tsx
@@ -6,8 +6,10 @@ import {
   AlertCircle,
   Calendar,
   Car,
+  Download,
   Eye,
   Fuel,
+  Loader2,
   type LucideIcon,
   MoreHorizontal,
   Search,
@@ -32,8 +34,17 @@ import { useTranslations } from "next-intl"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useAuth } from "@/providers/auth-provider"
 import { cn } from "@/lib/utils"
+import { exportUnitsToCSV } from "@/lib/csv/export-units"
 
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://127.0.0.1:3001";
+
+function normalize(str: string): string {
+  return str
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+}
 
 interface Unit {
   id: string;
@@ -78,12 +89,14 @@ export default function UnidadesPage() {
     fetchUnits();
   }, [walletAddress]);
 
+  const query = normalize(searchQuery)
   const filteredUnits = units.filter(
     (unit) =>
-      unit.make?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      unit.model?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      unit.plates?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      unit.user?.name?.toLowerCase().includes(searchQuery.toLowerCase()),
+      !query ||
+      normalize(unit.make ?? "").includes(query) ||
+      normalize(unit.model ?? "").includes(query) ||
+      normalize(unit.plates ?? "").includes(query) ||
+      normalize(unit.user?.name ?? "").includes(query),
   );
 
   if (loading) {
@@ -109,12 +122,10 @@ export default function UnidadesPage() {
         </div>
       </div>
     );
+  }
+
   const activeUnits = units.filter(unit => unit.isActive).length
   const assignedUnits = units.filter(unit => unit.user?.name).length
-
-  if (error) {
-    return <ErrorState title="Error al cargar unidades" message={error} />
-  }
 
   return (
     <div className="space-y-6">
@@ -123,6 +134,7 @@ export default function UnidadesPage() {
         <p className="text-muted-foreground">
           {t("subtitle")}
         </p>
+      </div>
       <PageHero
         eyebrow="Fleet registry"
         title="Flota"
@@ -144,17 +156,28 @@ export default function UnidadesPage() {
               <CardDescription>
                 {t("total", { count: units.length })}
               </CardDescription>
-              <CardTitle className="text-title text-white">Lista de vehículos</CardTitle>
-              <CardDescription>Total: {units.length} vehículos registrados</CardDescription>
             </div>
-            <div className="relative w-full sm:w-80">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder={t("searchPlaceholder")}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="bg-glass pl-10"
-              />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              {filteredUnits.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => exportUnitsToCSV(filteredUnits)}
+                  className="shrink-0"
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  {t("exportCsv")}
+                </Button>
+              )}
+              <div className="relative w-full sm:w-80">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  placeholder={t("searchPlaceholder")}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="bg-glass pl-10"
+                />
+              </div>
             </div>
           </div>
         </CardHeader>
@@ -233,8 +256,34 @@ export default function UnidadesPage() {
                 </div>
               ))}
             </div>
+          ) : units.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-glass-border bg-glass p-8 text-center">
+              <Car className="mx-auto h-10 w-10 text-muted-foreground" />
+              <p className="mt-3 font-medium text-foreground">
+                {t("emptyFleet")}
+              </p>
+              <p className="mt-1 text-body-sm text-muted-foreground">
+                {t("emptyFleetDescription")}
+              </p>
+            </div>
           ) : (
-            <EmptyState>No hay vehículos registrados</EmptyState>
+            <div className="rounded-lg border border-dashed border-glass-border bg-glass p-8 text-center">
+              <Search className="mx-auto h-10 w-10 text-muted-foreground" />
+              <p className="mt-3 font-medium text-foreground">
+                {t("noSearchResults")}
+              </p>
+              <p className="mt-1 text-body-sm text-muted-foreground">
+                {t("noSearchResultsDescription", { query: searchQuery })}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => setSearchQuery("")}
+              >
+                {t("clearSearch")}
+              </Button>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/frontend/app/dashboard/unidades/page.tsx
+++ b/frontend/app/dashboard/unidades/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import type { ReactNode } from "react"
 import {
   AlertCircle,
@@ -12,6 +12,7 @@ import {
   Loader2,
   type LucideIcon,
   MoreHorizontal,
+  RefreshCw,
   Search,
   User,
 } from "lucide-react"
@@ -46,6 +47,26 @@ function normalize(str: string): string {
     .replace(/[\u0300-\u036f]/g, "")
 }
 
+async function fetchWithRetry(
+  url: string,
+  { retries = 3, delay = 1000 } = {},
+): Promise<Response> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok && res.status >= 500 && retries > 0) {
+      await new Promise((r) => setTimeout(r, delay));
+      return fetchWithRetry(url, { retries: retries - 1, delay: delay * 2 });
+    }
+    return res;
+  } catch (err) {
+    if (retries > 0) {
+      await new Promise((r) => setTimeout(r, delay));
+      return fetchWithRetry(url, { retries: retries - 1, delay: delay * 2 });
+    }
+    throw err;
+  }
+}
+
 interface Unit {
   id: string;
   make: string;
@@ -68,26 +89,33 @@ export default function UnidadesPage() {
   const [units, setUnits] = useState<Unit[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [authError, setAuthError] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
-  useEffect(() => {
-    async function fetchUnits() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`${BACKEND}/api/v1/units`);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        setUnits(data.success && data.data ? data.data : []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : tCommon("connectionError"));
-        setUnits([]);
-      } finally {
-        setLoading(false);
+  const fetchUnits = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setAuthError(false);
+    try {
+      const res = await fetchWithRetry(`${BACKEND}/api/v1/units`);
+      if (res.status === 401 || res.status === 403) {
+        setAuthError(true);
+        setError(tCommon("connectionError"));
+        return;
       }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setUnits(data.success && data.data ? data.data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : tCommon("connectionError"));
+    } finally {
+      setLoading(false);
     }
+  }, [tCommon]);
+
+  useEffect(() => {
     fetchUnits();
-  }, [walletAddress]);
+  }, [fetchUnits, walletAddress]);
 
   const query = normalize(searchQuery)
   const filteredUnits = units.filter(
@@ -118,7 +146,29 @@ export default function UnidadesPage() {
           <p className="font-medium text-destructive">
             {t("loadError")}
           </p>
-          <p className="text-sm text-muted-foreground">{error}</p>
+          <p className="text-sm text-muted-foreground">
+            {authError ? t("authError") : error}
+          </p>
+          {authError ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.location.href = "/connect"}
+              className="mt-2"
+            >
+              {tCommon("disconnect")}
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchUnits()}
+              className="mt-2"
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {t("retryLoad")}
+            </Button>
+          )}
         </div>
       </div>
     );

--- a/frontend/lib/csv/export-units.ts
+++ b/frontend/lib/csv/export-units.ts
@@ -1,0 +1,73 @@
+interface Unit {
+  id: string
+  make: string
+  model: string
+  year?: number
+  plates: string
+  isActive: boolean
+  specs?: string
+  permitNumber?: string
+  permitExpiry?: string
+  user?: {
+    name: string
+  }
+}
+
+export type { Unit }
+
+export function safeCSVField(value: string | null | undefined): string {
+  if (value == null) return ''
+
+  if (/^[=+\-@\t\r]/.test(value.trimStart())) {
+    value = "'" + value
+  }
+
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    value = '"' + value.replace(/"/g, '""') + '"'
+  }
+
+  return value
+}
+
+function toCSVRow(fields: string[]): string {
+  return fields.map(safeCSVField).join(',')
+}
+
+export function exportUnitsToCSV(data: Unit[]): void {
+  const headers = [
+    'ID',
+    'Marca',
+    'Modelo',
+    'Año',
+    'Placas',
+    'Conductor',
+    'No. Permiso',
+    'Vencimiento Permiso',
+    'Estado',
+  ]
+
+  const rows = data.map((unit) =>
+    toCSVRow([
+      unit.id,
+      unit.make,
+      unit.model,
+      unit.year?.toString() ?? '',
+      unit.plates,
+      unit.user?.name ?? '',
+      unit.permitNumber ?? '',
+      unit.permitExpiry ?? '',
+      unit.isActive ? 'Activo' : 'Inactivo',
+    ]),
+  )
+
+  const csv = '\uFEFF' + [headers.join(','), ...rows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `flota_${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+
+  URL.revokeObjectURL(url)
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -222,7 +222,9 @@
     "noSearchResults": "No results found",
     "noSearchResultsDescription": "No vehicles match \"{query}\"",
     "clearSearch": "Clear search",
-    "exportCsv": "Export CSV"
+    "exportCsv": "Export CSV",
+    "authError": "Session expired. Connect your wallet to continue.",
+    "retryLoad": "Retry"
   },
   "usuarios": {
     "title": "Users",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -216,7 +216,13 @@
     "loadError": "Failed to load units",
     "listTitle": "Vehicle List",
     "total": "Total: {count} registered vehicles",
-    "searchPlaceholder": "Search vehicle..."
+    "searchPlaceholder": "Search vehicle...",
+    "emptyFleet": "No vehicles registered",
+    "emptyFleetDescription": "Start by adding your first vehicle to the fleet",
+    "noSearchResults": "No results found",
+    "noSearchResultsDescription": "No vehicles match \"{query}\"",
+    "clearSearch": "Clear search",
+    "exportCsv": "Export CSV"
   },
   "usuarios": {
     "title": "Users",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -222,7 +222,9 @@
     "noSearchResults": "No se encontraron resultados",
     "noSearchResultsDescription": "No se encontraron vehículos que coincidan con \"{query}\"",
     "clearSearch": "Limpiar búsqueda",
-    "exportCsv": "Exportar CSV"
+    "exportCsv": "Exportar CSV",
+    "authError": "Sesión expirada. Conecta tu wallet para continuar.",
+    "retryLoad": "Reintentar"
   },
   "usuarios": {
     "title": "Usuarios",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -216,7 +216,13 @@
     "loadError": "Error al cargar unidades",
     "listTitle": "Lista de Vehículos",
     "total": "Total: {count} vehículos registrados",
-    "searchPlaceholder": "Buscar vehículo..."
+    "searchPlaceholder": "Buscar vehículo...",
+    "emptyFleet": "No hay vehículos registrados",
+    "emptyFleetDescription": "Comienza agregando tu primer vehículo a la flota",
+    "noSearchResults": "No se encontraron resultados",
+    "noSearchResultsDescription": "No se encontraron vehículos que coincidan con \"{query}\"",
+    "clearSearch": "Limpiar búsqueda",
+    "exportCsv": "Exportar CSV"
   },
   "usuarios": {
     "title": "Usuarios",


### PR DESCRIPTION
Changes made:
- Added network retry, failure recovery, and state preservation
- Implemented exponential backoff retries (1s → 2s → 4s) for transient 5xx and network errors when fetching units. 
- Fast-fail on 401/403 auth errors with a wallet reconnect redirect. 
- Added manual "Reintentar" retry button in error UI. 
- Preserved searchQuery state across retry attempts.

Closes #66 