### PR TITLE
feat(fuel-price-oracle): persistent storage, admin key rotation, price events (Fixes #81)

### DIFF
--- a/contracts/fuel-price-oracle/src/lib.rs
+++ b/contracts/fuel-price-oracle/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Bytes, BytesN, Env, Map, Symbol,
+    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, Symbol,
 };
 
 /// Maximum age of a price update (1 hour).
@@ -12,6 +12,13 @@ pub const MXN_SCALE: u64 = 10_000;
 
 /// Fixed-point scale for USDC (7 decimals): 1.39 → 13_900_000.
 pub const USDC_SCALE: u64 = 10_000_000;
+
+/// Storage TTL refresh threshold in ledgers (~7 hours at 5s/ledger).
+/// When a key's remaining TTL drops below this, it is bumped on the next access.
+pub const TTL_THRESHOLD: u32 = 5_000;
+
+/// Storage TTL extension target in ledgers (~30 days at 5s/ledger).
+pub const TTL_EXTEND_TO: u32 = 518_400;
 
 #[contracttype]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -49,16 +56,37 @@ pub struct PriceData {
     pub station_id: soroban_sdk::String,
 }
 
+/// Storage keys. `Price` and `LastTimestamp` are stored as direct persistent
+/// entries (one row per fuel type) instead of a single instance map, so a
+/// price update only touches the affected fuel type.
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Designated admin that may rotate the oracle public key (instance storage).
+    Admin,
+    /// Authorized ed25519 public key that signs price updates (instance storage).
     OraclePubKey,
-    Prices,
-    LastTimestamps,
+    /// Certified price for a fuel type (persistent storage).
+    Price(FuelType),
+    /// Last accepted update timestamp per fuel type, for replay protection (persistent storage).
+    LastTimestamp(FuelType),
 }
 
 #[contract]
 pub struct FuelPriceOracle;
+
+/// Extends the TTL of the contract instance (and code) when it drops below the
+/// threshold, preventing instance data from expiring on-chain.
+fn extend_instance_ttl(env: &Env) {
+    env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+}
+
+/// Extends the TTL of a single persistent storage key.
+fn extend_persistent_ttl(env: &Env, key: &DataKey) {
+    env.storage()
+        .persistent()
+        .extend_ttl(key, TTL_THRESHOLD, TTL_EXTEND_TO);
+}
 
 fn build_message(
     env: &Env,
@@ -86,22 +114,25 @@ fn validate_timestamp(env: &Env, fuel_type: FuelType, timestamp: u64) {
         "Price timestamp expired"
     );
 
-    let last_timestamps = env
+    let last_ts_key = DataKey::LastTimestamp(fuel_type);
+    if let Some(last_ts) = env
         .storage()
-        .instance()
-        .get::<_, Map<FuelType, u64>>(&DataKey::LastTimestamps)
-        .unwrap_or_else(|| Map::new(env));
-
-    if let Some(last_ts) = last_timestamps.get(fuel_type) {
+        .persistent()
+        .get::<_, u64>(&last_ts_key)
+    {
+        extend_persistent_ttl(env, &last_ts_key);
         assert!(timestamp > last_ts, "Replay attack: stale timestamp");
     }
 }
 
 #[contractimpl]
 impl FuelPriceOracle {
-    /// Initialize oracle with authorized public key and seed prices (scaled fixed-point).
+    /// Initialize oracle with a designated admin, authorized public key, and
+    /// seed prices (scaled fixed-point).
+    #[allow(clippy::too_many_arguments)]
     pub fn init(
         env: Env,
+        admin: Address,
         oracle_pubkey: BytesN<32>,
         seed_magna_mxn: u64,
         seed_premium_mxn: u64,
@@ -113,60 +144,51 @@ impl FuelPriceOracle {
         assert!(
             env.storage()
                 .instance()
-                .get::<_, BytesN<32>>(&DataKey::OraclePubKey)
+                .get::<_, Address>(&DataKey::Admin)
                 .is_none(),
             "Already initialized"
         );
+        admin.require_auth();
 
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
             .instance()
             .set(&DataKey::OraclePubKey, &oracle_pubkey);
+        extend_instance_ttl(&env);
 
         let now = env.ledger().timestamp();
         let station = soroban_sdk::String::from_str(&env, "CRE-MX-SEED");
 
-        let mut prices = Map::<FuelType, PriceData>::new(&env);
-        let mut last_ts = Map::<FuelType, u64>::new(&env);
-
         let seeds = [
-            (
-                FuelType::Magna,
-                seed_magna_mxn,
-                seed_magna_usdc,
-            ),
-            (
-                FuelType::Premium,
-                seed_premium_mxn,
-                seed_premium_usdc,
-            ),
-            (
-                FuelType::Diesel,
-                seed_diesel_mxn,
-                seed_diesel_usdc,
-            ),
+            (FuelType::Magna, seed_magna_mxn, seed_magna_usdc),
+            (FuelType::Premium, seed_premium_mxn, seed_premium_usdc),
+            (FuelType::Diesel, seed_diesel_mxn, seed_diesel_usdc),
         ];
 
         for (fuel_type, price_mxn, price_usdc) in seeds {
-            prices.set(
-                fuel_type,
-                PriceData {
+            let price_key = DataKey::Price(fuel_type);
+            let last_ts_key = DataKey::LastTimestamp(fuel_type);
+
+            env.storage().persistent().set(
+                &price_key,
+                &PriceData {
                     price_mxn,
                     price_usdc,
                     timestamp: now,
                     station_id: station.clone(),
                 },
             );
-            last_ts.set(fuel_type, now);
+            env.storage().persistent().set(&last_ts_key, &now);
+            extend_persistent_ttl(&env, &price_key);
+            extend_persistent_ttl(&env, &last_ts_key);
         }
-
-        env.storage().instance().set(&DataKey::Prices, &prices);
-        env.storage()
-            .instance()
-            .set(&DataKey::LastTimestamps, &last_ts);
     }
 
     /// Update certified price for a fuel type. Signature covers
     /// [fuel_type, price_mxn, price_usdc, timestamp, station_id].
+    ///
+    /// Emits a `price_up` event with the accepted price data.
+    #[allow(deprecated)] // env.events().publish — kept for the exact topic/data shape in the spec
     pub fn update_price(
         env: Env,
         fuel_type_sym: Symbol,
@@ -186,6 +208,7 @@ impl FuelPriceOracle {
             .instance()
             .get::<_, BytesN<32>>(&DataKey::OraclePubKey)
             .unwrap_or_else(|| panic!("Oracle not initialized"));
+        extend_instance_ttl(&env);
 
         let message = build_message(
             &env,
@@ -199,32 +222,26 @@ impl FuelPriceOracle {
         env.crypto()
             .ed25519_verify(&oracle_pubkey, &message, &signature);
 
-        let mut prices = env
-            .storage()
-            .instance()
-            .get::<_, Map<FuelType, PriceData>>(&DataKey::Prices)
-            .unwrap_or_else(|| panic!("Oracle not initialized"));
+        let price_key = DataKey::Price(fuel_type);
+        let last_ts_key = DataKey::LastTimestamp(fuel_type);
 
-        prices.set(
-            fuel_type,
-            PriceData {
+        env.storage().persistent().set(
+            &price_key,
+            &PriceData {
                 price_mxn,
                 price_usdc,
                 timestamp,
                 station_id: station_id.clone(),
             },
         );
-        env.storage().instance().set(&DataKey::Prices, &prices);
+        env.storage().persistent().set(&last_ts_key, &timestamp);
+        extend_persistent_ttl(&env, &price_key);
+        extend_persistent_ttl(&env, &last_ts_key);
 
-        let mut last_timestamps = env
-            .storage()
-            .instance()
-            .get::<_, Map<FuelType, u64>>(&DataKey::LastTimestamps)
-            .unwrap_or_else(|| Map::new(&env));
-        last_timestamps.set(fuel_type, timestamp);
-        env.storage()
-            .instance()
-            .set(&DataKey::LastTimestamps, &last_timestamps);
+        env.events().publish(
+            (symbol_short!("price_up"), fuel_type_sym),
+            (price_mxn, price_usdc, timestamp, station_id),
+        );
     }
 
     /// Simplified entry point per spec: updates MAGNA price using scaled values.
@@ -234,15 +251,13 @@ impl FuelPriceOracle {
         timestamp: u64,
         signature: BytesN<64>,
     ) {
-        let prices = env
+        let price_key = DataKey::Price(FuelType::Magna);
+        let current = env
             .storage()
-            .instance()
-            .get::<_, Map<FuelType, PriceData>>(&DataKey::Prices)
-            .unwrap_or_else(|| panic!("Oracle not initialized"));
-
-        let current = prices
-            .get(FuelType::Magna)
+            .persistent()
+            .get::<_, PriceData>(&price_key)
             .unwrap_or_else(|| panic!("Magna price not set"));
+        extend_persistent_ttl(&env, &price_key);
 
         Self::update_price(
             env,
@@ -259,22 +274,47 @@ impl FuelPriceOracle {
         let fuel_type = FuelType::from_symbol(&env, &fuel_type_sym)
             .unwrap_or_else(|| panic!("Invalid fuel type"));
 
-        let prices = env
+        let price_key = DataKey::Price(fuel_type);
+        let price = env
+            .storage()
+            .persistent()
+            .get::<_, PriceData>(&price_key)
+            .unwrap_or_else(|| panic!("Price not found for fuel type"));
+        extend_persistent_ttl(&env, &price_key);
+        extend_instance_ttl(&env);
+
+        price
+    }
+
+    /// Rotate the oracle public key. Only the designated admin may do this.
+    pub fn set_oracle_pubkey(env: Env, admin: Address, new_pubkey: BytesN<32>) {
+        let stored_admin = env
             .storage()
             .instance()
-            .get::<_, Map<FuelType, PriceData>>(&DataKey::Prices)
-            .unwrap_or_else(|| panic!("Oracle not initialized"));
+            .get::<_, Address>(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
 
-        prices
-            .get(fuel_type)
-            .unwrap_or_else(|| panic!("Price not found for fuel type"))
+        assert!(
+            admin == stored_admin,
+            "Only admin can rotate the oracle public key"
+        );
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::OraclePubKey, &new_pubkey);
+        extend_instance_ttl(&env);
     }
 
     pub fn get_oracle_pubkey(env: Env) -> BytesN<32> {
-        env.storage()
+        let pubkey = env
+            .storage()
             .instance()
             .get(&DataKey::OraclePubKey)
-            .unwrap_or_else(|| panic!("Oracle not initialized"))
+            .unwrap_or_else(|| panic!("Oracle not initialized"));
+        extend_instance_ttl(&env);
+
+        pubkey
     }
 }
 

--- a/contracts/fuel-price-oracle/src/test/mod.rs
+++ b/contracts/fuel-price-oracle/src/test/mod.rs
@@ -6,8 +6,8 @@ use super::*;
 use std::vec::Vec;
 use ed25519_dalek::{Signer as DalekSigner, SigningKey};
 use sha2::{Digest, Sha256};
-use soroban_sdk::testutils::Ledger;
-use soroban_sdk::{symbol_short, BytesN, Env, String};
+use soroban_sdk::testutils::{Address as _, Events, Ledger};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol, TryFromVal, Val, Vec as SorobanVec};
 
 fn build_message_vec(
     fuel_type: FuelType,
@@ -61,11 +61,13 @@ fn scale_usdc(value: f64) -> u64 {
     (value * USDC_SCALE as f64).round() as u64
 }
 
-fn setup_initialized(env: &Env) -> FuelPriceOracleClient<'_> {
+fn setup_initialized_with_admin(env: &Env) -> (FuelPriceOracleClient<'_>, Address) {
     let contract_id = env.register(FuelPriceOracle, ());
     let client = FuelPriceOracleClient::new(env, &contract_id);
+    let admin = Address::generate(env);
 
     client.init(
+        &admin,
         &pubkey_bytes(env),
         &scale_mxn(24.0),
         &scale_mxn(28.66),
@@ -75,6 +77,11 @@ fn setup_initialized(env: &Env) -> FuelPriceOracleClient<'_> {
         &scale_usdc(1.59),
     );
 
+    (client, admin)
+}
+
+fn setup_initialized(env: &Env) -> FuelPriceOracleClient<'_> {
+    let (client, _admin) = setup_initialized_with_admin(env);
     client
 }
 
@@ -254,4 +261,94 @@ fn test_rejects_replay_timestamp() {
         &sig_replay,
     );
     assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_can_rotate_oracle_pubkey() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_initialized_with_admin(&env);
+
+    let new_key = BytesN::from_array(&env, &[7u8; 32]);
+    client.set_oracle_pubkey(&admin, &new_key);
+
+    assert_eq!(client.get_oracle_pubkey(), new_key);
+}
+
+#[test]
+fn test_rejects_non_admin_oracle_rotation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_initialized_with_admin(&env);
+
+    let impostor = Address::generate(&env);
+    let new_key = BytesN::from_array(&env, &[9u8; 32]);
+
+    let result = client.try_set_oracle_pubkey(&impostor, &new_key);
+    assert!(result.is_err());
+
+    // The stored key is unchanged.
+    assert_eq!(client.get_oracle_pubkey(), pubkey_bytes(&env));
+}
+
+#[test]
+fn test_update_price_emits_price_up_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_initialized(&env);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_748_304_000;
+    });
+
+    let price_mxn = scale_mxn(24.50);
+    let price_usdc = scale_usdc(1.42);
+    let timestamp = 1_748_304_000u64;
+    let station_id = String::from_str(&env, "CRE-MX-001");
+    let signature = sign_payload(
+        &env,
+        FuelType::Magna,
+        price_mxn,
+        price_usdc,
+        timestamp,
+        "CRE-MX-001",
+    );
+
+    client.update_price(
+        &symbol_short!("MAGNA"),
+        &price_mxn,
+        &price_usdc,
+        &timestamp,
+        &station_id,
+        &signature,
+    );
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+
+    let (_contract_id, topics, data) = events.get(0).unwrap();
+
+    let topic0 = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, symbol_short!("price_up"));
+
+    let topic1 = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+    assert_eq!(topic1, symbol_short!("MAGNA"));
+
+    let data_vec = SorobanVec::<Val>::try_from_val(&env, &data).unwrap();
+    assert_eq!(
+        u64::try_from_val(&env, &data_vec.get(0).unwrap()).unwrap(),
+        price_mxn
+    );
+    assert_eq!(
+        u64::try_from_val(&env, &data_vec.get(1).unwrap()).unwrap(),
+        price_usdc
+    );
+    assert_eq!(
+        u64::try_from_val(&env, &data_vec.get(2).unwrap()).unwrap(),
+        timestamp
+    );
+    assert_eq!(
+        String::try_from_val(&env, &data_vec.get(3).unwrap()).unwrap(),
+        station_id
+    );
 }


### PR DESCRIPTION
Closes #81

Refactors the uel-price-oracle contract: direct persistent storage, admin-governed key rotation, and on-chain price events.

## What changed
- **Storage model** - replaced the monolithic instance Map<FuelType, PriceData> / Map<FuelType, u64> with direct persistent keys:
  - \DataKey::Price(FuelType)\ and \DataKey::LastTimestamp(FuelType)\, stored via \env.storage().persistent()\. Updating one fuel type no longer re-serializes the whole map.
- **Admin & key rotation**:
  - \init\ now accepts \dmin: Address\ (stored under \DataKey::Admin\, with \equire_auth\).
  - New \set_oracle_pubkey(env, admin, new_pubkey)\ requires the designated admin to rotate the oracle public key.
- **Events** - \update_price\ publishes a \price_up\ event on success with topics \(symbol_short!("price_up"), fuel_type_sym)\ and data \(price_mxn, price_usdc, timestamp, station_id)\.
- **TTL extension** - explicit \extend_ttl\ calls on the contract instance and on persistent price/timestamp keys during reads and writes (\TTL_THRESHOLD\ / \TTL_EXTEND_TO\, ~30 days).

## Preserved
- \ed25519_verify\ signature validation and \alidate_timestamp\ rules (future / expiry / replay checks) are unchanged in behavior.
- \update_price_simple\ and \get_oracle_pubkey\ remain available.

## Tests
- Existing 5 tests updated for the new \dmin\ init parameter - all pass.
- New tests: admin key rotation, non-admin rotation rejected (key unchanged), and \price_up\ event emission verified (topics + data).
- \cargo test\: 8/8 pass; \cargo build --target wasm32-unknown-unknown --release\ builds.

Note: I verified tests on Windows by building the lib with \crate-type = ["rlib"]\ locally (the host cdylib can't link on Windows GNU/MSVC toolchains); the tracked \Cargo.toml\ is unchanged.