### PR TITLE
feat(hooks): enhance useOraclePrice with price selection and error ha…

### DIFF
--- a/frontend/__tests__/use-oracle-price.test.ts
+++ b/frontend/__tests__/use-oracle-price.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  roundFuelCost,
+  selectOraclePrice,
+  type SignedOraclePrice,
+} from '@/hooks/useOraclePrice'
+
+function signedPrice(
+  fuelType: string,
+  overrides: Partial<SignedOraclePrice['payload']> = {}
+): SignedOraclePrice {
+  return {
+    payload: {
+      fuelType,
+      pricePerLiter: 24.5,
+      timestamp: Date.now(),
+      ...overrides,
+    },
+    signature: 'sig',
+    oraclePublicKey: 'GTEST',
+  }
+}
+
+describe('selectOraclePrice', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('matches fuel types regardless of casing or surrounding whitespace', () => {
+    const prices = [signedPrice('DIESEL')]
+
+    expect(selectOraclePrice(prices, 'diesel')?.fuelType).toBe('DIESEL')
+    expect(selectOraclePrice(prices, 'Diesel')?.fuelType).toBe('DIESEL')
+    expect(selectOraclePrice(prices, '  DIESEL  ')?.fuelType).toBe('DIESEL')
+  })
+
+  it('returns null when no matching fuel type exists', () => {
+    const prices = [signedPrice('Magna')]
+
+    expect(selectOraclePrice(prices, 'Diesel')).toBeNull()
+  })
+
+  it('returns null for a null price list', () => {
+    expect(selectOraclePrice(null, 'Diesel')).toBeNull()
+  })
+
+  it('returns a fresh price within maxPriceAge', () => {
+    const prices = [signedPrice('Diesel', { timestamp: Date.now() - 60_000 })]
+
+    expect(selectOraclePrice(prices, 'Diesel', 10 * 60 * 1000)?.pricePerLiter).toBe(24.5)
+  })
+
+  it('returns null and warns when the price is older than maxPriceAge', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const prices = [
+      signedPrice('Diesel', { timestamp: Date.now() - 11 * 60 * 1000 }),
+    ]
+
+    expect(selectOraclePrice(prices, 'Diesel')).toBeNull()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toMatch(/expired/i)
+  })
+
+  it('does not treat a price at the maxPriceAge boundary as expired', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-27T12:00:00.000Z'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const maxPriceAge = 10 * 60 * 1000
+    const prices = [signedPrice('Diesel', { timestamp: Date.now() - maxPriceAge })]
+
+    expect(selectOraclePrice(prices, 'Diesel', maxPriceAge)?.fuelType).toBe('Diesel')
+    expect(warn).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})
+
+describe('roundFuelCost', () => {
+  it('rounds fiat costs to two decimal places', () => {
+    expect(roundFuelCost(50 * 24.555)).toBe(1227.75)
+    expect(roundFuelCost(10 * 27.449)).toBe(274.49)
+  })
+})

--- a/frontend/hooks/useOraclePrice.ts
+++ b/frontend/hooks/useOraclePrice.ts
@@ -33,33 +33,71 @@ interface UsePriceState {
 }
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1'
+const DEFAULT_MAX_PRICE_AGE_MS = 10 * 60 * 1000
+const POLL_INTERVAL_MS = 5 * 60 * 1000
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+export function selectOraclePrice(
+  prices: SignedOraclePrice[] | null,
+  fuelType: string,
+  maxPriceAge = DEFAULT_MAX_PRICE_AGE_MS
+): OraclePrice | null {
+  if (!prices) return null
+
+  const target = fuelType.toLowerCase().trim()
+  const signedPrice = prices.find(
+    (p) => p.payload.fuelType.toLowerCase().trim() === target
+  )
+
+  if (!signedPrice) return null
+
+  const age = Date.now() - signedPrice.payload.timestamp
+  if (age > maxPriceAge) {
+    console.warn(
+      `Oracle price for "${fuelType}" is expired (${Math.round(age / 1000)}s old, max ${Math.round(maxPriceAge / 1000)}s)`
+    )
+    return null
+  }
+
+  return signedPrice.payload
+}
+
+export function roundFuelCost(cost: number): number {
+  return Math.round(cost * 100) / 100
+}
 
 /**
  * useOraclePrice Hook
- * 
+ *
  * Fetches real-time fuel prices from the Tanko Oracle backend
  * Provides helpers to calculate fuel costs based on oracle prices
- * 
+ *
  * @example
  * const { prices, getPricePerLiter, calculateFuelCost } = useOraclePrice()
- * 
+ *
  * if (loading) return <div>Loading prices...</div>
  * if (error) return <div>Error: {error}</div>
- * 
+ *
  * const dieselPrice = getPricePerLiter('Diesel')
  * const cost = calculateFuelCost(50, 'Diesel') // 50 liters of Diesel
  */
 export function useOraclePrice(): UsePriceState {
   const [prices, setPrices] = useState<SignedOraclePrice[] | null>(null)
+  const [maxPriceAge, setMaxPriceAge] = useState(DEFAULT_MAX_PRICE_AGE_MS)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchPrices = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  const fetchPrices = useCallback(async (isSilent = false, signal?: AbortSignal) => {
+    if (!isSilent) {
+      setLoading(true)
+      setError(null)
+    }
 
     try {
-      const response = await fetch(`${API_BASE_URL}/oracle/prices`)
+      const response = await fetch(`${API_BASE_URL}/oracle/prices`, { signal })
 
       if (!response.ok) {
         throw new Error(`Failed to fetch prices: ${response.statusText}`)
@@ -69,35 +107,46 @@ export function useOraclePrice(): UsePriceState {
 
       if (data.success && data.data.prices) {
         setPrices(data.data.prices)
+        if (typeof data.data.maxPriceAge === 'number') {
+          setMaxPriceAge(data.data.maxPriceAge)
+        }
+        setError(null)
       } else {
         throw new Error('Invalid response format from oracle API')
       }
     } catch (err) {
+      if (isAbortError(err)) return
+
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch oracle prices'
       setError(errorMessage)
       console.error('Oracle price fetch error:', err)
     } finally {
-      setLoading(false)
+      if (!isSilent && !signal?.aborted) {
+        setLoading(false)
+      }
     }
   }, [])
 
   useEffect(() => {
-    fetchPrices()
+    const controller = new AbortController()
 
-    // Refresh prices every 5 minutes (300000ms)
-    const interval = setInterval(fetchPrices, 300000)
+    fetchPrices(false, controller.signal)
 
-    return () => clearInterval(interval)
+    const interval = setInterval(() => {
+      fetchPrices(true, controller.signal)
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      controller.abort()
+      clearInterval(interval)
+    }
   }, [fetchPrices])
 
   const getPrice = useCallback(
     (fuelType: string): OraclePrice | null => {
-      if (!prices) return null
-
-      const signedPrice = prices.find((p) => p.payload.fuelType === fuelType)
-      return signedPrice?.payload || null
+      return selectOraclePrice(prices, fuelType, maxPriceAge)
     },
-    [prices]
+    [prices, maxPriceAge]
   )
 
   const getPricePerLiter = useCallback(
@@ -116,7 +165,7 @@ export function useOraclePrice(): UsePriceState {
         return null
       }
 
-      return liters * pricePerLiter
+      return roundFuelCost(liters * pricePerLiter)
     },
     [getPricePerLiter]
   )


### PR DESCRIPTION
## Summary
- Match oracle fuel types case-insensitively (`diesel` / `Diesel` / `DIESEL`) and ignore surrounding whitespace
- Reject prices older than `maxPriceAge` (API value, or 10 minutes by default) and log a warning
- Poll `/oracle/prices` every 5 minutes without setting `loading = true`
- Abort in-flight fetches on unmount via `AbortController`
- Round `calculateFuelCost` to 2 decimal places

## Why
`useOraclePrice` used strict fuel-type equality, accepted stale timestamps, flashed the UI on every background poll, and left HTTP requests running after unmount.

## How it was tested
- `npm run test:run --workspace=frontend -- __tests__/use-oracle-price.test.ts`
- Case-insensitive lookup succeeds
- Prices older than `maxPriceAge` return `null` and warn
- Fiat cost rounding uses `Math.round(cost * 100) / 100`

Closes #82

## Test plan
- [x] Open a screen that uses `useOraclePrice` and confirm the first fetch shows loading
- [x] Confirm a later 5-minute poll updates prices without a loading flash
- [x] Request `diesel`, `Diesel`, and `DIESEL` and get the same price
- [x] With a timestamp older than 10 minutes (or API `maxPriceAge`), `getPrice` returns `null`
- [x] Leave the page while a fetch is in flight and confirm abort does not surface as a UI error